### PR TITLE
deploy-script: add heights

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -71,12 +71,18 @@ const HD_PATH = env.HD_PATH || utils.defaultPath;
   if (failedDeployments.length !== 0)
     throw new Error(`Contract deployment failed: ${failedDeployments.join(',')}`);
 
+  // Slightly different schema for the AddressManager, OVM_Sequencer
+  // and Deployer, maintains backwards compat
   const out = {};
   out.AddressManager = AddressManager.address;
   out.OVM_Sequencer = SEQUENCER_ADDRESS;
   out.Deployer = await signer.getAddress()
-  for (const [name, contract] of Object.entries(result.contracts)) {
-    out[name] = contract.address;
+  for (const [name, info] of Object.entries(result.contracts)) {
+    out[name] = {
+      address: info.contract.address,
+      blockNumber: info.receipt.blockNumber,
+      transactionHash: info.receipt.transactionHash
+    };
   }
   console.log(JSON.stringify(out, null, 2));
 })().catch(err => {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@ethersproject/hardware-wallets": "^5.0.8",
+    "@ethersproject/abstract-provider": "^5.0.5",
     "ethers": "5.0.0"
   },
   "devDependencies": {

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -1,5 +1,6 @@
 /* External Imports */
 import { Signer, ContractFactory, Contract } from 'ethers'
+import { TransactionReceipt } from '@ethersproject/abstract-provider'
 
 /* Internal Imports */
 import { getContractFactory } from '../contract-defs'
@@ -29,7 +30,9 @@ export interface RollupDeployConfig {
 export interface ContractDeployParameters {
   factory: ContractFactory
   params?: any[]
-  afterDeploy?: (contracts?: { [name: string]: Contract }) => Promise<void>
+  afterDeploy?: (contracts?: {
+    [name: string]: { contract: Contract; receipt: TransactionReceipt }
+  }) => Promise<void>
 }
 
 export interface ContractDeployConfig {
@@ -63,14 +66,14 @@ export const makeContractDeployConfig = async (
             : await sequencer.getAddress()
         await AddressManager.setAddress('OVM_Sequencer', sequencerAddress)
         await AddressManager.setAddress('Sequencer', sequencerAddress)
-        await contracts.OVM_CanonicalTransactionChain.init()
+        await contracts.OVM_CanonicalTransactionChain.contract.init()
       },
     },
     OVM_StateCommitmentChain: {
       factory: getContractFactory('OVM_StateCommitmentChain'),
       params: [AddressManager.address],
       afterDeploy: async (contracts): Promise<void> => {
-        await contracts.OVM_StateCommitmentChain.init()
+        await contracts.OVM_StateCommitmentChain.contract.init()
       },
     },
     OVM_DeployerWhitelist: {
@@ -101,8 +104,8 @@ export const makeContractDeployConfig = async (
       factory: getContractFactory('OVM_StateManager'),
       params: [await config.deploymentSigner.getAddress()],
       afterDeploy: async (contracts): Promise<void> => {
-        await contracts.OVM_StateManager.setExecutionManager(
-          contracts.OVM_ExecutionManager.address
+        await contracts.OVM_StateManager.contract.setExecutionManager(
+          contracts.OVM_ExecutionManager.contract.address
         )
       },
     },

--- a/src/contract-dumps.ts
+++ b/src/contract-dumps.ts
@@ -146,7 +146,8 @@ export const makeStateDump = async (): Promise<any> => {
   }
 
   const deploymentResult = await deploy(config)
-  deploymentResult.contracts['Lib_AddressManager'] =
+  deploymentResult.contracts['Lib_AddressManager'] = {} as any
+  deploymentResult.contracts['Lib_AddressManager'].contract =
     deploymentResult.AddressManager
 
   if (deploymentResult.failedDeployments.length > 0) {
@@ -164,10 +165,10 @@ export const makeStateDump = async (): Promise<any> => {
 
   for (let i = 0; i < Object.keys(deploymentResult.contracts).length; i++) {
     const name = Object.keys(deploymentResult.contracts)[i]
-    const contract = deploymentResult.contracts[name]
+    const result = deploymentResult.contracts[name]
 
     const codeBuf = await pStateManager.getContractCode(
-      fromHexString(contract.address)
+      fromHexString(result.contract.address)
     )
     const code = toHexString(codeBuf)
 
@@ -179,14 +180,14 @@ export const makeStateDump = async (): Promise<any> => {
       address: deadAddress,
       code,
       codeHash: keccak256(code),
-      storage: await getStorageDump(cStateManager, contract.address),
+      storage: await getStorageDump(cStateManager, result.contract.address),
       abi: getContractDefinition(name.replace('Proxy__', '')).abi,
     }
   }
 
   const addressMap = Object.keys(dump.accounts).map((name) => {
     return {
-      originalAddress: deploymentResult.contracts[name].address,
+      originalAddress: deploymentResult.contracts[name].contract.address,
       deadAddress: dump.accounts[name].address,
     }
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,7 +128,7 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
-"@ethersproject/abstract-provider@5.0.5", "@ethersproject/abstract-provider@^5.0.0", "@ethersproject/abstract-provider@^5.0.4":
+"@ethersproject/abstract-provider@5.0.5", "@ethersproject/abstract-provider@^5.0.0", "@ethersproject/abstract-provider@^5.0.4", "@ethersproject/abstract-provider@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.0.5.tgz#797a32a8707830af1ad8f833e9c228994d5572b9"
   integrity sha512-i/CjElAkzV7vQBAeoz+IpjGfcFYEP9eD7j3fzZ0fzTq03DO7PPnR+xkEZ1IoDXGwDS+55aLM1xvLDwB/Lx6IOQ==


### PR DESCRIPTION
## Description

Adds the deploy height to the output of the deploy script. This is useful for booting up geth because the CTC deploy height is a config param. This is used as the height of the L1 chain to start syncing from. To get this, I needed to get the receipt for each contract being deployed. This required me to update the interfaces to some functions.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
