### PR TITLE
deploy targets: add configurable deployment targets

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const contracts = require('../build/src/contract-deployment/deploy');
+const DeployTarget = require('../build/src/helpers')
 const { providers, Wallet, utils } = require('ethers');
 const { LedgerSigner } = require('@ethersproject/hardware-wallets');
 const { JsonRpcProvider } = providers;
@@ -54,6 +55,7 @@ const L2_CROSS_DOMAIN_MESSENGER_ADDRESS =
 
   const result = await contracts.deploy({
     deploymentSigner: signer,
+    deployTarget: DeployTarget.L1,
     transactionChainConfig: {
       forceInclusionPeriodSeconds: FORCE_INCLUSION_PERIOD_SECONDS,
       sequencer: SEQUENCER_ADDRESS,

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const contracts = require('../build/src/contract-deployment/deploy');
-const DeployTarget = require('../build/src/helpers')
+const {DeployTarget} = require('../build/src/contract-deployment/helpers')
 const { providers, Wallet, utils } = require('ethers');
 const { LedgerSigner } = require('@ethersproject/hardware-wallets');
 const { JsonRpcProvider } = providers;
@@ -25,7 +25,6 @@ const USE_LEDGER = env.USE_LEDGER || false;
 const HD_PATH = env.HD_PATH || utils.defaultPath;
 const L2_CROSS_DOMAIN_MESSENGER_ADDRESS =
   env.L2_CROSS_DOMAIN_MESSENGER_ADDRESS || '0x4200000000000000000000000000000000000007';
-
 
 
 (async () => {

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -8,7 +8,7 @@ import { DeploymentTarget, DeployTarget } from './helpers'
 
 export interface RollupDeployConfig {
   deploymentSigner: Signer
-  deploymentTarget: DeploymentTarget,
+  deploymentTarget: DeploymentTarget
   ovmGasMeteringConfig: {
     minTransactionGasLimit: number
     maxTransactionGasLimit: number
@@ -37,7 +37,7 @@ export interface RollupDeployConfig {
 
 export interface ContractDeployParameters {
   factory: ContractFactory
-  deploymentTarget: DeploymentTarget,
+  deploymentTarget: DeploymentTarget
   params?: any[]
   afterDeploy?: (contracts?: { [name: string]: Contract }) => Promise<void>
 }

--- a/src/contract-deployment/config.ts
+++ b/src/contract-deployment/config.ts
@@ -4,9 +4,11 @@ import { Overrides } from '@ethersproject/contracts'
 
 /* Internal Imports */
 import { getContractFactory } from '../contract-defs'
+import { DeploymentTarget, DeployTarget } from './helpers'
 
 export interface RollupDeployConfig {
   deploymentSigner: Signer
+  deploymentTarget: DeploymentTarget,
   ovmGasMeteringConfig: {
     minTransactionGasLimit: number
     maxTransactionGasLimit: number
@@ -35,6 +37,7 @@ export interface RollupDeployConfig {
 
 export interface ContractDeployParameters {
   factory: ContractFactory
+  deploymentTarget: DeploymentTarget,
   params?: any[]
   afterDeploy?: (contracts?: { [name: string]: Contract }) => Promise<void>
 }
@@ -51,10 +54,12 @@ export const makeContractDeployConfig = async (
     OVM_L2CrossDomainMessenger: {
       factory: getContractFactory('OVM_L2CrossDomainMessenger'),
       params: [AddressManager.address],
+      deploymentTarget: DeployTarget.L2,
     },
     OVM_L1CrossDomainMessenger: {
       factory: getContractFactory('OVM_L1CrossDomainMessenger'),
       params: [],
+      deploymentTarget: DeployTarget.L1,
     },
     Proxy__OVM_L1CrossDomainMessenger: {
       factory: getContractFactory('Lib_ResolvedDelegateProxy'),
@@ -71,6 +76,7 @@ export const makeContractDeployConfig = async (
           config.ovmGlobalContext.L2CrossDomainMessengerAddress
         )
       },
+      deploymentTarget: DeployTarget.L1,
     },
     OVM_CanonicalTransactionChain: {
       factory: getContractFactory('OVM_CanonicalTransactionChain'),
@@ -88,6 +94,7 @@ export const makeContractDeployConfig = async (
         await AddressManager.setAddress('Sequencer', sequencerAddress)
         await contracts.OVM_CanonicalTransactionChain.init()
       },
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_StateCommitmentChain: {
       factory: getContractFactory('OVM_StateCommitmentChain'),
@@ -99,22 +106,27 @@ export const makeContractDeployConfig = async (
       afterDeploy: async (contracts): Promise<void> => {
         await contracts.OVM_StateCommitmentChain.init()
       },
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_DeployerWhitelist: {
       factory: getContractFactory('OVM_DeployerWhitelist'),
       params: [],
+      deploymentTarget: DeployTarget.L2,
     },
     OVM_L1MessageSender: {
       factory: getContractFactory('OVM_L1MessageSender'),
       params: [],
+      deploymentTarget: DeployTarget.L2,
     },
     OVM_L2ToL1MessagePasser: {
       factory: getContractFactory('OVM_L2ToL1MessagePasser'),
       params: [],
+      deploymentTarget: DeployTarget.L2,
     },
     OVM_SafetyChecker: {
       factory: getContractFactory('OVM_SafetyChecker'),
       params: [],
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_ExecutionManager: {
       factory: getContractFactory('OVM_ExecutionManager'),
@@ -123,6 +135,7 @@ export const makeContractDeployConfig = async (
         config.ovmGasMeteringConfig,
         config.ovmGlobalContext,
       ],
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_StateManager: {
       factory: getContractFactory('OVM_StateManager'),
@@ -132,31 +145,40 @@ export const makeContractDeployConfig = async (
           contracts.OVM_ExecutionManager.address
         )
       },
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_StateManagerFactory: {
       factory: getContractFactory('OVM_StateManagerFactory'),
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_FraudVerifier: {
       factory: getContractFactory('OVM_FraudVerifier'),
       params: [AddressManager.address],
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_StateTransitionerFactory: {
       factory: getContractFactory('OVM_StateTransitionerFactory'),
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_ECDSAContractAccount: {
       factory: getContractFactory('OVM_ECDSAContractAccount'),
+      deploymentTarget: DeployTarget.L2,
     },
     OVM_SequencerEntrypoint: {
       factory: getContractFactory('OVM_SequencerEntrypoint'),
+      deploymentTarget: DeployTarget.L1L2,
     },
     OVM_ProxySequencerEntrypoint: {
       factory: getContractFactory('OVM_ProxySequencerEntrypoint'),
+      deploymentTarget: DeployTarget.L2,
     },
     mockOVM_ECDSAContractAccount: {
       factory: getContractFactory('mockOVM_ECDSAContractAccount'),
+      deploymentTarget: DeployTarget.L2,
     },
     OVM_BondManager: {
       factory: getContractFactory('mockOVM_BondManager'),
+      deploymentTarget: DeployTarget.L1L2,
     },
   }
 }

--- a/src/contract-deployment/deploy.ts
+++ b/src/contract-deployment/deploy.ts
@@ -39,7 +39,12 @@ export const deploy = async (
       continue
     }
 
-    if (!shouldDeploy(config.deploymentTarget, contractDeployParameters.deploymentTarget)) {
+    if (
+      !shouldDeploy(
+        config.deploymentTarget,
+        contractDeployParameters.deploymentTarget
+      )
+    ) {
       continue
     }
 

--- a/src/contract-deployment/deploy.ts
+++ b/src/contract-deployment/deploy.ts
@@ -4,6 +4,7 @@ import { Signer, Contract, ContractFactory } from 'ethers'
 /* Internal Imports */
 import { RollupDeployConfig, makeContractDeployConfig } from './config'
 import { getContractFactory } from '../contract-defs'
+import { shouldDeploy } from './helpers'
 
 export interface DeployResult {
   AddressManager: Contract
@@ -35,6 +36,10 @@ export const deploy = async (
     contractDeployConfig
   )) {
     if (config.dependencies && !config.dependencies.includes(name)) {
+      continue
+    }
+
+    if (!shouldDeploy(config.deploymentTarget, contractDeployParameters.deploymentTarget)) {
       continue
     }
 

--- a/src/contract-deployment/helpers.ts
+++ b/src/contract-deployment/helpers.ts
@@ -11,7 +11,7 @@ export interface DeployTargets {
 // A bitfield that represents deployment targets.
 export const DeployTarget: DeployTargets = {
   L1: 1 as DeploymentTarget,
-  L2: 1 << 1 as DeploymentTarget,
+  L2: (1 << 1) as DeploymentTarget,
   L1L2: ((1 << 1) | 1) as DeploymentTarget,
 }
 

--- a/src/contract-deployment/helpers.ts
+++ b/src/contract-deployment/helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Deployment Helpers
+ */
+
+export type DeploymentTarget = 1 | 2 | 3
+
+export interface DeployTargets {
+  [target: string]: DeploymentTarget
+}
+
+// A bitfield that represents deployment targets.
+export const DeployTarget: DeployTargets = {
+  L1: 1 as DeploymentTarget,
+  L2: 1 << 1 as DeploymentTarget,
+  L1L2: ((1 << 1) | 1) as DeploymentTarget,
+}
+
+export function shouldDeploy(target: number, remote: number): boolean {
+  if (target & remote) {
+    return true
+  }
+  return false
+}

--- a/src/contract-deployment/index.ts
+++ b/src/contract-deployment/index.ts
@@ -1,2 +1,3 @@
 export { RollupDeployConfig } from './config'
 export { deploy } from './deploy'
+export { shouldDeploy, DeployTarget } from './helpers'

--- a/src/contract-dumps.ts
+++ b/src/contract-dumps.ts
@@ -5,7 +5,7 @@ import * as Ganache from 'ganache-core'
 import { keccak256 } from 'ethers/lib/utils'
 
 /* Internal Imports */
-import { deploy, RollupDeployConfig } from './contract-deployment'
+import { deploy, RollupDeployConfig, DeployTarget } from './contract-deployment'
 import { fromHexString, toHexString, remove0x } from './utils'
 import { getContractDefinition } from './contract-defs'
 
@@ -110,6 +110,7 @@ export const makeStateDump = async (): Promise<any> => {
 
   const config: RollupDeployConfig = {
     deploymentSigner: signer,
+    deploymentTarget: DeployTarget.L2,
     ovmGasMeteringConfig: {
       minTransactionGasLimit: 0,
       maxTransactionGasLimit: 1_000_000_000,


### PR DESCRIPTION
## Description

Adds the ability to specify a deployment target and the ability to selectively deploy to either L1 or L2


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
