### PR TITLE
Changed transaction type enums

### DIFF
--- a/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
+++ b/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
@@ -106,11 +106,11 @@ contract OVM_SequencerEntrypoint {
     {
         if (_transactionType == 0) {
             return TransactionType.NATIVE_ETH_TRANSACTION;
-        } if (_transactionType == 2) {
+        } if (_transactionType == 1) {
             return TransactionType.ETH_SIGNED_MESSAGE;
         } else {
             Lib_SafeExecutionManagerWrapper.safeREVERT(
-                "Transaction type must be 0 or 2"
+                "Transaction type must be 0 or 1"
             );
         }
     }

--- a/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -25,8 +25,11 @@ const callPrecompile = async (
   if (gasLimit) {
     return Helper_PrecompileCaller.callPrecompile(
       precompile.address,
-      precompile.interface.encodeFunctionData(functionName, functionParams || []),
-      {gasLimit}
+      precompile.interface.encodeFunctionData(
+        functionName,
+        functionParams || []
+      ),
+      { gasLimit }
     )
   }
   return Helper_PrecompileCaller.callPrecompile(
@@ -187,7 +190,7 @@ describe('OVM_ECDSAContractAccount', () => {
     it(`should revert on incorrect nonce`, async () => {
       const alteredNonceTx = {
         ...DEFAULT_EIP155_TX,
-        nonce : 99
+        nonce: 99,
       }
       const message = serializeNativeTransaction(alteredNonceTx)
       const sig = await signNativeTransaction(wallet, alteredNonceTx)
@@ -241,7 +244,7 @@ describe('OVM_ECDSAContractAccount', () => {
     it(`should revert on insufficient gas`, async () => {
       const alteredInsufficientGasTx = {
         ...DEFAULT_EIP155_TX,
-        gasLimit : 200000000
+        gasLimit: 200000000,
       }
       const message = serializeNativeTransaction(alteredInsufficientGasTx)
       const sig = await signNativeTransaction(wallet, alteredInsufficientGasTx)
@@ -257,7 +260,7 @@ describe('OVM_ECDSAContractAccount', () => {
           `0x${sig.r}`, //r
           `0x${sig.s}`, //s
         ],
-        40000000,
+        40000000
       )
 
       const ovmREVERT: any =

--- a/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
+++ b/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
@@ -133,11 +133,11 @@ describe('OVM_SequencerEntrypoint', () => {
       })
     }
 
-    it('should submit ETHSignedTypedData if TransactionType is 2', async () => {
+    it('should submit ETHSignedTypedData if TransactionType is 1', async () => {
       const calldata = await encodeSequencerCalldata(
         wallet,
         DEFAULT_EIP155_TX,
-        2
+        1
       )
       await Helper_PrecompileCaller.callPrecompile(
         OVM_SequencerEntrypoint.address,
@@ -162,18 +162,8 @@ describe('OVM_SequencerEntrypoint', () => {
     })
 
     // TODO: These tests should pass when smock is updated to >=0.1.0
-    it.skip('should revert if TransactionType is >2', async () => {
-      const calldata = '0x03'
-      await expect(
-        Helper_PrecompileCaller.callPrecompile(
-          OVM_SequencerEntrypoint.address,
-          calldata
-        )
-      ).to.be.reverted
-    })
-
-    it.skip('should revert if TransactionType is 1', async () => {
-      const calldata = '0x01'
+    it.skip('should revert if TransactionType is >1', async () => {
+      const calldata = '0x02'
       await expect(
         Helper_PrecompileCaller.callPrecompile(
           OVM_SequencerEntrypoint.address,

--- a/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
+++ b/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
@@ -42,11 +42,14 @@ describe('Lib_RLPWriter', () => {
     }
   })
 
-  describe.only('Use of library with other memory-modifying operations', () => {
+  describe('Use of library with other memory-modifying operations', () => {
     it('should allow creation of a contract beforehand and still work', async () => {
       const randomAddress = '0x1234123412341234123412341234123412341234'
-      const rlpEncodedRandomAddress = '0x941234123412341234123412341234123412341234'
-      const encoded = await Lib_RLPWriter.callStatic.writeAddressWithOtherMemory(randomAddress)
+      const rlpEncodedRandomAddress =
+        '0x941234123412341234123412341234123412341234'
+      const encoded = await Lib_RLPWriter.callStatic.writeAddressWithOtherMemory(
+        randomAddress
+      )
       expect(encoded).to.eq(rlpEncodedRandomAddress)
     })
   })

--- a/test/helpers/codec/encoding.ts
+++ b/test/helpers/codec/encoding.ts
@@ -135,7 +135,7 @@ export const signTransaction = async (
   transaction: EIP155Transaction,
   transactionType: number
 ): Promise<SignatureParameters> => {
-  return transactionType === 2
+  return transactionType === 1
     ? signEthSignMessage(wallet, transaction) //ETH Signed tx
     : signNativeTransaction(wallet, transaction) //Create EOA tx or EIP155 tx
 }
@@ -147,10 +147,5 @@ export const encodeSequencerCalldata = async (
 ) => {
   const sig = await signTransaction(wallet, transaction, transactionType)
   const encodedTransaction = encodeCompactTransaction(transaction)
-  const dataPrefix = `0x0${transactionType}${sig.r}${sig.s}${sig.v}`
-  const calldata =
-    transactionType === 1
-      ? `${dataPrefix}${remove0x(sig.messageHash)}` // Create EOA tx
-      : `${dataPrefix}${encodedTransaction}` // EIP155 tx or ETH Signed Tx
-  return calldata
+  return `0x0${transactionType}${sig.r}${sig.s}${sig.v}${encodedTransaction}`
 }


### PR DESCRIPTION
## Description
Changes enums for the sequencer entrypoint from `0` and `2` to `0` and `1`, in order to match geth. 

@tynes

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
