### PR TITLE
script: serve state dump

### DIFF
--- a/bin/serve_dump.sh
+++ b/bin/serve_dump.sh
@@ -8,9 +8,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
-# requires python3 for now
 PYTHON=${PYTHON:-python}
-
 HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-8081}
 DIRECTORY=$DIR/../build/dumps

--- a/bin/serve_dump.sh
+++ b/bin/serve_dump.sh
@@ -25,11 +25,15 @@ VERSION=$($PYTHON --version 2>&1 \
     |  sed -Ee's#([^/]).([^/]).([^/])#\1#')
 
 
-if [[ $VERSION != 3 ]]; then
-    echo "Must use python 3"
-    exit 1
+if [[ $VERSION == 3 ]]; then
+    $PYTHON -m http.server \
+        --bind $HOST $PORT \
+        --directory $DIRECTORY
+else
+    (
+        echo "Serving HTTP on $HOST port $PORT"
+        cd $DIRECTORY
+        $PYTHON -c \
+            'import BaseHTTPServer as bhs, SimpleHTTPServer as shs; bhs.HTTPServer(("'$HOST'", '"$PORT"'), shs.SimpleHTTPRequestHandler).serve_forever()'
+    )
 fi
-
-$PYTHON -m http.server \
-    --bind $HOST $PORT \
-    --directory $DIRECTORY

--- a/bin/serve_dump.sh
+++ b/bin/serve_dump.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Run this script to serve the latest state dump from
+# an http server. This is useful to serve the state dump
+# to a local instance of the sequencer/verifier during
+# development. The state dump can be found at
+# `GET /state-dump.latest.json`
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# requires python3 for now
+PYTHON=${PYTHON:-python}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-8081}
+DIRECTORY=$DIR/../build/dumps
+
+if [ ! command -v $PYTHON&>/dev/null ]; then
+    echo "Please install python"
+    exit 1
+fi
+
+VERSION=$($PYTHON --version 2>&1 \
+    | cut -d ' ' -f2 \
+    |  sed -Ee's#([^/]).([^/]).([^/])#\1#')
+
+
+if [[ $VERSION != 3 ]]; then
+    echo "Must use python 3"
+    exit 1
+fi
+
+$PYTHON -m http.server \
+    --bind $HOST $PORT \
+    --directory $DIRECTORY

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint:fix": "yarn run lint:fix:typescript",
     "lint:fix:typescript": "prettier --config prettier-config.json --write \"hardhat.config.ts\" \"{src,test}/**/*.ts\"",
     "clean": "rm -rf ./artifacts ./build ./cache",
-    "deploy": "./bin/deploy.js"
+    "deploy": "./bin/deploy.js",
+    "serve": "./bin/serve_dump.sh"
   },
   "dependencies": {
     "@eth-optimism/solc": "^0.6.12-alpha.1",


### PR DESCRIPTION
## Description

A script for serving the state dump on localhost. Usage:

```bash
$ yarn build
$ yarn serve
```

This depends on python3 being installed locally


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
