### PR TITLE
Trigger an error when running npm instead of yarn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@eth-optimism/contracts",
   "version": "0.1.5",
   "main": "build/src/index.js",
+  "engines": {
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.10"
+  },
   "files": [
     "build/**/*.js",
     "build/contracts/*",


### PR DESCRIPTION
## Description

Apparently running `npm` instead of `yarn` has caused some issues? This'd prevent that.

Running `npm i` prints:

```
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for @eth-optimism/contracts@0.1.5: wanted: {"npm":"please-use-yarn","yarn":">= 1.22.10"} (current: {"node":"12.18.4","npm":"6.14.6"})
npm ERR! notsup Not compatible with your version of node/npm: @eth-optimism/contracts@0.1.5
npm ERR! notsup Not compatible with your version of node/npm: @eth-optimism/contracts@0.1.5
npm ERR! notsup Required: {"npm":"please-use-yarn","yarn":">= 1.22.10"}
npm ERR! notsup Actual:   {"npm":"6.14.6","node":"12.18.4"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/primary/.npm/_logs/2021-02-17T18_01_50_361Z-debug.log
```