### PR TITLE
[Fix] Run CI from forked repo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
+  # pull_request:
+  #   branches:
+  #     - master
+  pull_request_target:
+    braches:
       - master
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
   pull_request_target:
     braches:
       - master


### PR DESCRIPTION
## Description

Addresses https://github.com/ethereum-optimism/roadmap/issues/643

This PR attempts to move the CI logic to run in the forked context instead of in our home repo.

## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
