### PR TITLE
[Fix] Run integration tests in forked context

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   pull_request_target:
     branches:
       - master

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches:
       - master
-  # pull_request:
-  #   branches:
-  #     - master
-  pull_request_target:
+  pull_request:
     branches:
       - master
+  pull_request_target:
+    types: [opened]
 
 jobs:
   build:
@@ -19,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build
+      - name: Build integration
         run: |
           git clone https://github.com/ethereum-optimism/optimism-integration.git \
               $HOME/optimism-integration
@@ -32,11 +31,6 @@ jobs:
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
           REMOTE="https://github.com/${{ github.repository }}"
-          echo "optimism-integration $GIT_COMMIT"
-          echo "$GITHUB_HEAD_REF"
-          echo "${{ github.repository }}"
-          echo "${{ github.event }}"
-          echo "${{ github.event_name }}"
           ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,10 @@ jobs:
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
           REMOTE="https://github.com/${{ github.repository }}"
           echo "optimism-integration $GIT_COMMIT"
+          echo "$GITHUB_HEAD_REF"
+          echo "${{ github.repository }}"
+          echo "${{ github.event }}"
+          echo "${{ github.event_name }}"
           ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  pull_request_target:
-    types: [opened]
 
 jobs:
   build:
@@ -16,33 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJSON(job) }}
-        run: echo "$JOB_CONTEXT"
-      - name: Dump steps context
-        env:
-          STEPS_CONTEXT: ${{ toJSON(steps) }}
-        run: echo "$STEPS_CONTEXT"
-      - name: Dump runner context
-        env:
-          RUNNER_CONTEXT: ${{ toJSON(runner) }}
-        run: echo "$RUNNER_CONTEXT"
-      - name: Dump strategy context
-        env:
-          STRATEGY_CONTEXT: ${{ toJSON(strategy) }}
-        run: echo "$STRATEGY_CONTEXT"
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{ toJSON(matrix) }}
-        run: echo "$MATRIX_CONTEXT"
-      
       - uses: actions/checkout@v2
-      - name: Build integration
+      - name: Build
         run: |
           git clone https://github.com/ethereum-optimism/optimism-integration.git \
               $HOME/optimism-integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
-          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.url }}
+          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.html_url }}
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
-          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.html_url }}
+          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.url }}
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,8 +54,7 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
-          REMOTE="https://github.com/${{ github.repository }}"
-          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r $REMOTE
+          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.html_url }}
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,8 +16,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        run: echo "$STEPS_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJSON(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJSON(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJSON(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+      
       - uses: actions/checkout@v2
-
       - name: Build integration
         run: |
           git clone https://github.com/ethereum-optimism/optimism-integration.git \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
-          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.html_url }}
+          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.html_url }}
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,8 +28,9 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
+          REMOTE=${{ github.event.pull_request.head.repo.html_url }}
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.html_url }}
+          ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
+  # pull_request:
+  #   branches:
+  #     - master
   pull_request_target:
     branches:
       - master

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Build
         run: |
           git clone https://github.com/ethereum-optimism/optimism-integration.git \
@@ -27,6 +28,7 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
+          echo "optimism-integration $GIT_COMMIT"
           ./docker/build.sh -s deployer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.html_url }}
 
       - name: Test


### PR DESCRIPTION
## Description

Addresses ethereum-optimism/roadmap#643

This PR attempts to move the CI logic to run in the forked context instead of in our home repo.

## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
