### PR TITLE
 [WIP] Clarifying comments for chainID recovery logic

### DIFF
--- a/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -10,6 +10,8 @@ import { NON_ZERO_ADDRESS } from '../../../helpers/constants'
 import {
   serializeNativeTransaction,
   signNativeTransaction,
+  // `DEFAULT_EIP155_TX` comes with `chainId: 420` encoded as a key-value pair,
+  // along with other transaction data
   DEFAULT_EIP155_TX,
   serializeEthSignTransaction,
   signEthSignMessage,
@@ -216,9 +218,11 @@ describe('OVM_ECDSAContractAccount', () => {
     })
 
     it(`should revert on incorrect chainId`, async () => {
+      // `DEFAULT_EIP155_TX` comes with `chainId: 420` encoded as a key-value
+      //  pair, along with other transaction data.
       const alteredChainIdTx = {
         ...DEFAULT_EIP155_TX,
-        chainId: 421,
+        chainId: 421, // Overwrites the default `chainId: 420`.
       }
       const message = serializeNativeTransaction(alteredChainIdTx)
       const sig = await signNativeTransaction(wallet, alteredChainIdTx)

--- a/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
+++ b/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
@@ -11,6 +11,8 @@ import {
   encodeSequencerCalldata,
   signNativeTransaction,
   signEthSignMessage,
+  // `DEFAULT_EIP155_TX` comes with `chainId: 420` encoded as a key-value pair,
+  // along with other transaction data
   DEFAULT_EIP155_TX,
   serializeNativeTransaction,
   serializeEthSignTransaction,

--- a/test/helpers/codec/encoding.ts
+++ b/test/helpers/codec/encoding.ts
@@ -22,13 +22,14 @@ export interface SignatureParameters {
   s: string
 }
 
+// Used in OVM_ECDSAContractAccount.spec.ts and OVM_SequencerEntrypoint.spec.ts
 export const DEFAULT_EIP155_TX: EIP155Transaction = {
   to: `0x${'12'.repeat(20)}`,
   nonce: 100,
   gasLimit: 1000000,
   gasPrice: 100000000,
   data: `0x${'99'.repeat(10)}`,
-  chainId: 420,
+  chainId: 420, // Encoding chainId. Test in OVM_ECDSAContractAccount.spec.ts
 }
 
 export const getRawSignedComponents = (signed: string): any[] => {


### PR DESCRIPTION
## Description

**NOTE: This is a draft** 

1. Trace the use of `DEFAULT_EIP155_TX` which sets `chainId` to 420.
2. Add better comments for how `DEFAULT_EIP155_TX` works and where it's used (where needed in `OVM_<CONTRACT>.spec.ts`).

## Questions
- Is this the correct location of initial encoding?

### Fixes
- Fixes #243.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
