### PR TITLE
feat: allow appending extraData on withdrawals

### DIFF
--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -64,7 +64,8 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      */
     function _handleFinalizeWithdrawal(
         address _to,
-        uint256 _amount
+        uint256 _amount,
+        bytes memory extraData
     )
         internal
         virtual
@@ -190,10 +191,12 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      *
      * @param _to L1 address to credit the withdrawal to
      * @param _amount Amount of the ERC20 to withdraw
+     * @param _extraData Any additional data to be committed to as part of the withdrawal message. The data does not need to be interpreted or executed on L1, it just needs to be hashed into the `relayedMessages` array in the L1 messenger so that 
      */
     function finalizeWithdrawal(
         address _to,
-        uint _amount
+        uint _amount,
+        bytes memory _extraData
     )
         external
         override 
@@ -202,9 +205,10 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
         // Call our withdrawal accounting handler implemented by child contracts.
         _handleFinalizeWithdrawal(
             _to,
-            _amount
+            _amount,
+            _extraData
         );
 
-        emit WithdrawalFinalized(_to, _amount);
+        emit WithdrawalFinalized(_to, _amount, _extraData);
     }
 }

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -147,13 +147,14 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _amount Amount of the token to withdraw
      */
     function withdraw(
-        uint _amount
+        uint _amount,
+        bytes memory extraData
     )
         external
         override
         onlyInitialized()
     {
-        _initiateWithdrawal(msg.sender, _amount);
+        _initiateWithdrawal(msg.sender, _amount, extraData);
     }
 
     /**
@@ -161,8 +162,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _to L1 adress to credit the withdrawal to
      * @param _amount Amount of the token to withdraw
      */
-    function withdrawTo(address _to, uint _amount) external override onlyInitialized() {
-        _initiateWithdrawal(_to, _amount);
+    function withdrawTo(address _to, uint _amount, bytes memory extraData) external override onlyInitialized() {
+        _initiateWithdrawal(_to, _amount, extraData);
     }
 
     /**
@@ -171,15 +172,16 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _to Account to give the withdrawal to on L1
      * @param _amount Amount of the token to withdraw
      */
-    function _initiateWithdrawal(address _to, uint _amount) internal {
+    function _initiateWithdrawal(address _to, uint _amount, bytes memory extraData) internal {
         // Call our withdrawal accounting handler implemented by child contracts (usually a _burn)
         _handleInitiateWithdrawal(_to, _amount);
 
-        // Construct calldata for l1TokenGateway.finalizeWithdrawal(_to, _amount)
+        // Construct calldata for l1TokenGateway.finalizeWithdrawal(_to, _amount, extraData)
         bytes memory data = abi.encodeWithSelector(
             iOVM_L1TokenGateway.finalizeWithdrawal.selector,
             _to,
-            _amount
+            _amount,
+            extraData
         );
 
         // Send message up to L1 gateway
@@ -189,7 +191,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             getFinalizeWithdrawalL1Gas()
         );
 
-        emit WithdrawalInitiated(msg.sender, _to, _amount);
+        emit WithdrawalInitiated(msg.sender, _to, _amount, extraData);
     }
 
     /************************************

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -89,7 +89,8 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
      */
     function _handleFinalizeWithdrawal(
         address _to,
-        uint _amount
+        uint _amount,
+        bytes memory // The extra data does not need to do anything. It just gets used to commit to additional info in the L2.
     )
         internal
         override

--- a/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -19,7 +19,8 @@ interface iOVM_L1TokenGateway {
   
     event WithdrawalFinalized(
         address indexed _to,
-        uint256 _amount
+        uint256 _amount,
+        bytes extraData
     );
 
 
@@ -45,7 +46,8 @@ interface iOVM_L1TokenGateway {
 
     function finalizeWithdrawal(
         address _to,
-        uint _amount
+        uint _amount,
+        bytes memory extraData
     )
         external;
 

--- a/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -14,7 +14,8 @@ interface iOVM_L2DepositedToken {
     event WithdrawalInitiated(
         address indexed _from,
         address _to,
-        uint256 _amount
+        uint256 _amount,
+        bytes extraData
     );
 
     event DepositFinalized(
@@ -28,13 +29,15 @@ interface iOVM_L2DepositedToken {
      ********************/
 
     function withdraw(
-        uint _amount
+        uint _amount,
+        bytes memory extraData
     )
         external;
 
     function withdrawTo(
         address _to,
-        uint _amount
+        uint _amount,
+        bytes memory extraData
     )
         external;
 

--- a/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
+++ b/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
@@ -81,7 +81,7 @@ describe('OVM_L1ERC20Gateway', () => {
       )
 
       await expect(
-        OVM_L1ERC20Gateway.finalizeWithdrawal(ZERO_ADDRESS, 1)
+        OVM_L1ERC20Gateway.finalizeWithdrawal(ZERO_ADDRESS, 1, "0x")
       ).to.be.revertedWith(ERR_INVALID_MESSENGER)
     })
 
@@ -91,7 +91,7 @@ describe('OVM_L1ERC20Gateway', () => {
       )
 
       await expect(
-        OVM_L1ERC20Gateway.finalizeWithdrawal(ZERO_ADDRESS, 1, {
+        OVM_L1ERC20Gateway.finalizeWithdrawal(ZERO_ADDRESS, 1, "0x", {
           from: Mock__OVM_L1CrossDomainMessenger.address,
         })
       ).to.be.revertedWith(ERR_INVALID_X_DOMAIN_MSG_SENDER)
@@ -111,6 +111,7 @@ describe('OVM_L1ERC20Gateway', () => {
       const res = await OVM_L1ERC20Gateway.finalizeWithdrawal(
         NON_ZERO_ADDRESS,
         withdrawalAmount,
+        "0x",
         { from: Mock__OVM_L1CrossDomainMessenger.address }
       )
 


### PR DESCRIPTION
## Description

This enables an L2 user to provide additional data, which can be then
used by L1 contracts. The L1 contract would provide the same data, and it
would then be checked against the hash of `relayedMessages` on the L1 Messenger
