### PR TITLE
Remove gas estimators from gateway interface

### DIFF
--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -100,7 +100,6 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     function getFinalizeDepositL2Gas()
         public
         view
-        override
         returns(
             uint32
         )

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -129,7 +129,6 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         public
         view
         virtual
-        override
         returns(
             uint32
         )
@@ -161,7 +160,14 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _to L1 adress to credit the withdrawal to
      * @param _amount Amount of the token to withdraw
      */
-    function withdrawTo(address _to, uint _amount) external override onlyInitialized() {
+    function withdrawTo(
+        address _to,
+        uint _amount
+    )
+        external
+        override
+        onlyInitialized()
+    {
         _initiateWithdrawal(_to, _amount);
     }
 
@@ -171,7 +177,12 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _to Account to give the withdrawal to on L1
      * @param _amount Amount of the token to withdraw
      */
-    function _initiateWithdrawal(address _to, uint _amount) internal {
+    function _initiateWithdrawal(
+        address _to,
+        uint _amount
+    )
+        internal
+    {
         // Call our withdrawal accounting handler implemented by child contracts (usually a _burn)
         _handleInitiateWithdrawal(_to, _amount);
 
@@ -204,7 +215,13 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _to Address to receive the withdrawal at
      * @param _amount Amount of the token to withdraw
      */
-    function finalizeDeposit(address _to, uint _amount) external override onlyInitialized()
+    function finalizeDeposit(
+        address _to,
+        uint _amount
+    )
+        external
+        override 
+        onlyInitialized()
         onlyFromCrossDomainAccount(address(l1TokenGateway))
     {
         _handleFinalizeDeposit(_to, _amount);

--- a/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -48,11 +48,4 @@ interface iOVM_L1TokenGateway {
         uint _amount
     )
         external;
-
-    function getFinalizeDepositL2Gas()
-        external
-        view
-        returns(
-            uint32
-        );
 }

--- a/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -48,11 +48,4 @@ interface iOVM_L2DepositedToken {
         uint _amount
     )
         external;
-
-    function getFinalizeWithdrawalL1Gas()
-        external
-        view
-        returns(
-            uint32
-        );
 }


### PR DESCRIPTION
## Description
Early user feedback suggests this results in more pain than gain, so this makes the gas estimators optional.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
