### PR TITLE
tests: fix the enums to match what is batch submitted

### DIFF
--- a/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
+++ b/contracts/optimistic-ethereum/OVM/precompiles/OVM_SequencerEntrypoint.sol
@@ -9,12 +9,12 @@ import { Lib_SafeExecutionManagerWrapper } from "../../libraries/wrappers/Lib_Sa
 
 /**
  * @title OVM_SequencerEntrypoint
- * @dev The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by 
- * any account. It accepts a more efficient compressed calldata format, which it decompresses and 
+ * @dev The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by
+ * any account. It accepts a more efficient compressed calldata format, which it decompresses and
  * encodes to the standard EIP155 transaction format.
  * This contract is the implementation referenced by the Proxy Sequencer Entrypoint, thus enabling
  * the Optimism team to upgrade the decompression of calldata from the Sequencer.
- * 
+ *
  * Compiler used: solc
  * Runtime target: OVM
  */
@@ -23,7 +23,7 @@ contract OVM_SequencerEntrypoint {
     /*********
      * Enums *
      *********/
-    
+
     enum TransactionType {
         NATIVE_ETH_TRANSACTION,
         ETH_SIGNED_MESSAGE
@@ -36,7 +36,7 @@ contract OVM_SequencerEntrypoint {
 
     /**
      * Uses a custom "compressed" format to save on calldata gas:
-     * calldata[00:01]: transaction type (0 == EIP 155, 2 == Eth Sign Message)
+     * calldata[00:01]: transaction type (0 == EIP 155, 1 == Eth Sign Message)
      * calldata[01:33]: signature "r" parameter
      * calldata[33:65]: signature "s" parameter
      * calldata[65:66]: signature "v" parameter
@@ -95,7 +95,7 @@ contract OVM_SequencerEntrypoint {
             callbytes
         );
     }
-    
+
 
     /**********************
      * Internal Functions *
@@ -116,11 +116,11 @@ contract OVM_SequencerEntrypoint {
     {
         if (_transactionType == 0) {
             return TransactionType.NATIVE_ETH_TRANSACTION;
-        } if (_transactionType == 2) {
+        } if (_transactionType == 1) {
             return TransactionType.ETH_SIGNED_MESSAGE;
         } else {
             Lib_SafeExecutionManagerWrapper.safeREVERT(
-                "Transaction type must be 0 or 2"
+                "Transaction type must be 0 or 1"
             );
         }
     }

--- a/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
+++ b/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
@@ -16,7 +16,7 @@ import {
   serializeEthSignTransaction,
 } from '../../../helpers'
 
-describe('OVM_SequencerEntrypoint', () => {
+describe.only('OVM_SequencerEntrypoint', () => {
   let wallet: Wallet
   before(async () => {
     const provider = waffle.provider
@@ -108,7 +108,7 @@ describe('OVM_SequencerEntrypoint', () => {
       expect(ovmCALL._calldata).to.equal(expectedEOACalldata)
     })
 
-    for (let i = 0; i < 3; i += 2) {
+    for (let i = 0; i < 2; i++) {
       it(`should call ovmCreateEOA when tx type is ${i} and ovmEXTCODESIZE returns 0`, async () => {
         Mock__OVM_ExecutionManager.smocked.ovmEXTCODESIZE.will.return.with(0)
         const calldata = await encodeSequencerCalldata(
@@ -131,11 +131,11 @@ describe('OVM_SequencerEntrypoint', () => {
       })
     }
 
-    it('should submit ETHSignedTypedData if TransactionType is 2', async () => {
+    it('should submit ETHSignedTypedData if TransactionType is 1', async () => {
       const calldata = await encodeSequencerCalldata(
         wallet,
         DEFAULT_EIP155_TX,
-        2
+        1
       )
       await Helper_PrecompileCaller.callPrecompile(
         OVM_SequencerEntrypoint.address,
@@ -159,18 +159,8 @@ describe('OVM_SequencerEntrypoint', () => {
       expect(ovmCALL._calldata).to.equal(expectedEOACalldata)
     })
 
-    it('should revert if TransactionType is >2', async () => {
-      const calldata = '0x03'
-      await expect(
-        Helper_PrecompileCaller.callPrecompile(
-          OVM_SequencerEntrypoint.address,
-          calldata
-        )
-      ).to.be.reverted
-    })
-
-    it('should revert if TransactionType is 1', async () => {
-      const calldata = '0x01'
+    it('should revert if TransactionType is >1', async () => {
+      const calldata = '0x02'
       await expect(
         Helper_PrecompileCaller.callPrecompile(
           OVM_SequencerEntrypoint.address,

--- a/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
+++ b/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
@@ -16,7 +16,7 @@ import {
   serializeEthSignTransaction,
 } from '../../../helpers'
 
-describe.only('OVM_SequencerEntrypoint', () => {
+describe('OVM_SequencerEntrypoint', () => {
   let wallet: Wallet
   before(async () => {
     const provider = waffle.provider

--- a/test/helpers/codec/encoding.ts
+++ b/test/helpers/codec/encoding.ts
@@ -3,7 +3,7 @@ import { ethers } from 'hardhat'
 import { Wallet } from 'ethers'
 
 /* Internal Imports */
-import { remove0x, fromHexString } from '@eth-optimism/core-utils'
+import { remove0x, fromHexString, TxType } from '@eth-optimism/core-utils'
 import { ZERO_ADDRESS } from '../constants'
 
 export interface EIP155Transaction {
@@ -131,9 +131,9 @@ export const signTransaction = async (
   transaction: EIP155Transaction,
   transactionType: number
 ): Promise<SignatureParameters> => {
-  return transactionType === 2
-    ? signEthSignMessage(wallet, transaction) //ETH Signed tx
-    : signNativeTransaction(wallet, transaction) //Create EOA tx or EIP155 tx
+  return transactionType === TxType.EthSign
+    ? signEthSignMessage(wallet, transaction) // ETH Signed tx
+    : signNativeTransaction(wallet, transaction) // EIP155 tx
 }
 
 export const encodeSequencerCalldata = async (
@@ -144,9 +144,6 @@ export const encodeSequencerCalldata = async (
   const sig = await signTransaction(wallet, transaction, transactionType)
   const encodedTransaction = encodeCompactTransaction(transaction)
   const dataPrefix = `0x0${transactionType}${sig.r}${sig.s}${sig.v}`
-  const calldata =
-    transactionType === 1
-      ? `${dataPrefix}${remove0x(sig.messageHash)}` // Create EOA tx
-      : `${dataPrefix}${encodedTransaction}` // EIP155 tx or ETH Signed Tx
+  const calldata = `${dataPrefix}${encodedTransaction}`
   return calldata
 }


### PR DESCRIPTION
## Description

This is a requirement for https://github.com/ethereum-optimism/go-ethereum/pull/255
The enums that were batch submitted to L1 were different than what the contracts expected, so geth had to fix them before passing along to the OVM. The above PR removes any logic in geth around modifying the transactions, it just passes the data through

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
