### PR TITLE
dev: Update TypeChain usage

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,7 +8,7 @@ import {
 // Hardhat plugins
 import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
-import 'hardhat-typechain'
+import '@typechain/hardhat'
 import '@eth-optimism/plugins/hardhat/compiler'
 import '@eth-optimism/smock/build/src/plugins/hardhat-storagelayout'
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build/**/*.js",
     "build/contracts/*",
     "build/dumps/*json",
-    "build/artifacts/**/*.json"
+    "build/artifacts/**/*.json",
+    "build/types/**/*.ts"
   ],
   "license": "MIT",
   "scripts": {
@@ -39,6 +40,7 @@
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/hardware-wallets": "^5.0.8",
     "@openzeppelin/contracts": "^3.3.0",
+    "@typechain/hardhat": "^1.0.1",
     "ganache-core": "^2.12.1",
     "glob": "^7.1.6"
   },
@@ -56,7 +58,6 @@
     "ethereum-waffle": "3.0.0",
     "ethers": "^5.0.31",
     "hardhat": "^2.0.8",
-    "hardhat-typechain": "^0.3.4",
     "lodash": "^4.17.20",
     "merkle-patricia-tree": "^4.0.0",
     "merkletreejs": "^0.2.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,11 @@
   dependencies:
     ethers "^5.0.2"
 
+"@typechain/hardhat@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@typechain/hardhat/-/hardhat-1.0.1.tgz#6e53956c15b2aff073413cfcdb3f5339b0a85f2e"
+  integrity sha512-gRETPlvLdN95PIP3PVktEtQSnSMJMWxaxNKI34KFPYEuW4QLLm6UrUCHWmulhB1eUQ1EhYRAda7kEhcJOQ/M1g==
+
 "@types/abstract-leveldown@*":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz#3c7750d0186b954c7f2d2f6acc8c3c7ba0c3412e"
@@ -4495,11 +4500,6 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
-
-hardhat-typechain@^0.3.4:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/hardhat-typechain/-/hardhat-typechain-0.3.5.tgz#8e50616a9da348b33bd001168c8fda9c66b7b4af"
-  integrity sha512-w9lm8sxqTJACY+V7vijiH+NkPExnmtiQEjsV9JKD1KgMdVk2q8y+RhvU/c4B7+7b1+HylRUCxpOIvFuB3rE4+w==
 
 hardhat@^2.0.3, hardhat@^2.0.8:
   version "2.0.10"


### PR DESCRIPTION
## Description
`hardhat-typechain` moved over to `@typechain/hardhat`. The (wonderful) maintainers over there also just published a new release after patching an issue we had with the plugin: https://github.com/ethereum-ts/TypeChain/pull/341 so our TypeChain outputs are working again. I went ahead and added the TypeChain outputs to the package.json too (although I'm not sure if this is strictly necessary).

## Questions
- Any thoughts on having the TypeChain outputs in the npm package?

## Metadata
### Fixes
- Fixes #295 

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
