### PR TITLE
[WIP] fix: Limit nonce to uint64 for consistency

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -446,7 +446,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         override
         public
         returns (
-            uint256 _nonce
+            uint64 _nonce
         )
     {
         return _getAccountNonce(ovmADDRESS());
@@ -457,7 +457,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      * @param _nonce New nonce for the current contract.
      */
     function ovmSETNONCE(
-        uint256 _nonce
+        uint64 _nonce
     )
         override
         public
@@ -1136,7 +1136,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function _setAccountNonce(
         address _address,
-        uint256 _nonce
+        uint64 _nonce
     )
         internal
     {
@@ -1154,7 +1154,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         internal
         returns (
-            uint256 _nonce
+            uint64 _nonce
         )
     {
         _checkAccountLoad(_address);

--- a/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
@@ -207,7 +207,7 @@ contract OVM_StateManager is iOVM_StateManager {
      */
     function setAccountNonce(
         address _address,
-        uint256 _nonce
+        uint64 _nonce
     )
         override
         public
@@ -228,7 +228,7 @@ contract OVM_StateManager is iOVM_StateManager {
         public
         view
         returns (
-            uint256
+            uint64
         )
     {
         return accounts[_address].nonce;

--- a/contracts/optimistic-ethereum/iOVM/execution/iOVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/iOVM/execution/iOVM_ExecutionManager.sol
@@ -120,8 +120,8 @@ interface iOVM_ExecutionManager {
      * Account Abstraction Opcodes *
      ******************************/
 
-    function ovmGETNONCE() external returns (uint256 _nonce);
-    function ovmSETNONCE(uint256 _nonce) external;
+    function ovmGETNONCE() external returns (uint64 _nonce);
+    function ovmSETNONCE(uint64 _nonce) external;
     function ovmCREATEEOA(bytes32 _messageHash, uint8 _v, bytes32 _r, bytes32 _s) external;
 
 

--- a/contracts/optimistic-ethereum/iOVM/execution/iOVM_StateManager.sol
+++ b/contracts/optimistic-ethereum/iOVM/execution/iOVM_StateManager.sol
@@ -45,8 +45,8 @@ interface iOVM_StateManager {
     function getAccount(address _address) external view returns (Lib_OVMCodec.Account memory _account);
     function hasAccount(address _address) external view returns (bool _exists);
     function hasEmptyAccount(address _address) external view returns (bool _exists);
-    function setAccountNonce(address _address, uint256 _nonce) external;
-    function getAccountNonce(address _address) external view returns (uint256 _nonce);
+    function setAccountNonce(address _address, uint64 _nonce) external;
+    function getAccountNonce(address _address) external view returns (uint64 _nonce);
     function getAccountEthAddress(address _address) external view returns (address _ethAddress);
     function getAccountStorageRoot(address _address) external view returns (bytes32 _storageRoot);
     function initPendingAccount(address _address) external;

--- a/contracts/optimistic-ethereum/libraries/codec/Lib_OVMCodec.sol
+++ b/contracts/optimistic-ethereum/libraries/codec/Lib_OVMCodec.sol
@@ -34,7 +34,7 @@ library Lib_OVMCodec {
      ***********/
 
     struct Account {
-        uint256 nonce;
+        uint64 nonce;
         uint256 balance;
         bytes32 storageRoot;
         bytes32 codeHash;
@@ -43,7 +43,7 @@ library Lib_OVMCodec {
     }
 
     struct EVMAccount {
-        uint256 nonce;
+        uint64 nonce;
         uint256 balance;
         bytes32 storageRoot;
         bytes32 codeHash;
@@ -307,7 +307,7 @@ library Lib_OVMCodec {
         // index-by-index circumvents this issue.
         raw[0] = Lib_RLPWriter.writeBytes(
             Lib_Bytes32Utils.removeLeadingZeros(
-                bytes32(_account.nonce)
+                bytes32(uint256(_account.nonce))
             )
         );
         raw[1] = Lib_RLPWriter.writeBytes(
@@ -338,7 +338,7 @@ library Lib_OVMCodec {
         Lib_RLPReader.RLPItem[] memory accountState = Lib_RLPReader.readList(_encoded);
 
         return EVMAccount({
-            nonce: Lib_RLPReader.readUint256(accountState[0]),
+            nonce: uint64(Lib_RLPReader.readUint256(accountState[0])),
             balance: Lib_RLPReader.readUint256(accountState[1]),
             storageRoot: Lib_RLPReader.readBytes32(accountState[2]),
             codeHash: Lib_RLPReader.readBytes32(accountState[3])


### PR DESCRIPTION
## Description
Geth treats nonces as `uint64` limiting it in the contracts is easier than changing all references in Geth. WIP, needs tests.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
