### PR TITLE
Reset context on return

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -631,7 +631,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     {
         // DELEGATECALL does not change anything about the message context.
         MessageContext memory nextMessageContext = messageContext;
-        
+
         bool isStaticEntrypoint = false;
 
         return _callContract(
@@ -1509,6 +1509,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         if (isCreation) {
             messageRecord.revertFlag = _flag;
 
+			_resetContext();
             assembly {
                 return(0, 1)
             }


### PR DESCRIPTION
## Description

Fixes a bug that left the EM context initialized after a call. 

Fixes: https://github.com/ethereum-optimism/roadmap/issues/781

I looked for other assembly level `return` opcodes, and did not find any.