### PR TITLE
Fix simulateMessage for eth_calls

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -1837,9 +1837,23 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         _initContext(_transaction);
 
         messageRecord.nuisanceGasLeft = uint(-1);
-        messageContext.ovmADDRESS = _transaction.entrypoint;
-        messageContext.ovmCALLER = _from;
 
-        return _transaction.entrypoint.call{gas: _transaction.gasLimit}(_transaction.data);
+        messageContext.ovmADDRESS = _from;
+
+        bool isCreate = _transaction.entrypoint == address(0);
+        if (isCreate) {
+            address created = ovmCREATE(_transaction.data);
+            if (created == address(0)) {
+                return (false, hex"");
+            } else {
+                return (true, Lib_EthUtils.getCode(created));
+            }
+        } else {
+            return ovmCALL(
+                _transaction.gasLimit,
+                _transaction.entrypoint,
+                _transaction.data
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description
This allows deployed code to be correctly returned by geth in L2 during `eth_call`.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
