### PR TITLE
Rename all instances of push2 to pushTwo and get2 to getTwo

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -313,14 +313,14 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
 
         iOVM_ChainStorageContainer queueRef = queue();
 
-        queueRef.push2(
+        queueRef.pushTwo(
             transactionHash,
             timestampAndBlockNumber
         );
 
         // The underlying queue data structure stores 2 elements
         // per insertion, so to get the real queue length we need
-        // to divide by 2 and subtract 1. See the usage of `push2(..)`.
+        // to divide by 2 and subtract 1. See the usage of `pushTwo(..)`.
         uint256 queueIndex = queueRef.length() / 2 - 1;
         emit TransactionEnqueued(
             msg.sender,
@@ -751,11 +751,11 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     {
         // The underlying queue data structure stores 2 elements
         // per insertion, so to get the actual desired queue index
-        // we need to multiply by 2. See the usage of `push2(..)`.
+        // we need to multiply by 2. See the usage of `pushTwo(..)`.
         (
             bytes32 transactionHash,
             bytes32 timestampAndBlockNumber
-        ) = _queueRef.get2(uint40(_index * 2));
+        ) = _queueRef.getTwo(uint40(_index * 2));
 
         uint40 elementTimestamp;
         uint40 elementBlockNumber;
@@ -786,7 +786,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     {
         // The underlying queue data structure stores 2 elements
         // per insertion, so to get the real queue length we need
-        // to divide by 2. See the usage of `push2(..)`.
+        // to divide by 2. See the usage of `pushTwo(..)`.
         return uint40(_queueRef.length() / 2);
     }
 

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -145,7 +145,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
-    function push2(
+    function pushTwo(
         bytes32 _objectA,
         bytes32 _objectB
     )
@@ -153,13 +153,13 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
         public
         onlyOwner
     {
-        buffer.push2(_objectA, _objectB);
+        buffer.pushTwo(_objectA, _objectB);
     }
 
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
-    function push2(
+    function pushTwo(
         bytes32 _objectA,
         bytes32 _objectB,
         bytes27 _globalMetadata
@@ -168,7 +168,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
         public
         onlyOwner
     {
-        buffer.push2(_objectA, _objectB, _globalMetadata);
+        buffer.pushTwo(_objectA, _objectB, _globalMetadata);
     }
 
     /**
@@ -190,7 +190,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
-    function get2(
+    function getTwo(
         uint256 _index
     )
         override
@@ -201,7 +201,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
             bytes32
         )
     {
-        return buffer.get2(uint40(_index));
+        return buffer.getTwo(uint40(_index));
     }
     
     /**

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
@@ -70,7 +70,7 @@ interface iOVM_ChainStorageContainer {
      * @param _objectA First 32 byte value to insert into the container.
      * @param _objectB Second 32 byte value to insert into the container.
      */
-    function push2(
+    function pushTwo(
         bytes32 _objectA,
         bytes32 _objectB
     )
@@ -83,7 +83,7 @@ interface iOVM_ChainStorageContainer {
      * @param _objectB Second 32 byte value to insert into the container.
      * @param _globalMetadata New global metadata for the container.
      */
-    function push2(
+    function pushTwo(
         bytes32 _objectA,
         bytes32 _objectB,
         bytes27 _globalMetadata
@@ -110,7 +110,7 @@ interface iOVM_ChainStorageContainer {
      * @return 32 byte object value at index `_index`.
      * @return 32 byte object value at index `_index + 1`.
      */
-    function get2(
+    function getTwo(
         uint256 _index
     )
         external

--- a/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -118,7 +118,7 @@ library Lib_RingBuffer {
      * @param _valueA Second value to push to the buffer.
      * @param _extraData Optional global extra data.
      */
-    function push2(
+    function pushTwo(
         RingBuffer storage _self,
         bytes32 _valueA,
         bytes32 _valueB,
@@ -136,7 +136,7 @@ library Lib_RingBuffer {
      * @param _valueA First value to push to the buffer.
      * @param _valueA Second value to push to the buffer.
      */
-    function push2(
+    function pushTwo(
         RingBuffer storage _self,
         bytes32 _valueA,
         bytes32 _valueB
@@ -145,7 +145,7 @@ library Lib_RingBuffer {
     {
         RingBufferContext memory ctx = _self.getContext();
 
-        _self.push2(
+        _self.pushTwo(
             _valueA,
             _valueB,
             ctx.extraData
@@ -218,7 +218,7 @@ library Lib_RingBuffer {
      * @return Value of the element at index `_index`.
      * @return Value of the element at index `_index + 1`.
      */
-    function get2(
+    function getTwo(
         RingBuffer storage _self,
         uint256 _index
     )

--- a/contracts/test-libraries/utils/TestLib_RingBuffer.sol
+++ b/contracts/test-libraries/utils/TestLib_RingBuffer.sol
@@ -25,14 +25,14 @@ contract TestLib_RingBuffer {
         );
     }
 
-    function push2(
+    function pushTwo(
         bytes32 _valueA,
         bytes32 _valueB,
         bytes27 _extraData
     )
         public
     {
-        buf.push2(
+        buf.pushTwo(
             _valueA,
             _valueB,
             _extraData


### PR DESCRIPTION
## Description
Push2 is a solidity opcode, so we want to make sure that there is clear differentiation between the opcode and function names. This PR renames all instances of push2 to pushTwo and get2 to getTwo.

## Metadata
### Fixes
- Fixes #318

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
