### PR TITLE
fix: Clear Compiler Warnings

### DIFF
--- a/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
@@ -41,7 +41,7 @@ abstract contract Abs_BaseCrossDomainMessenger is iAbs_BaseCrossDomainMessenger,
      * Public Functions *
      ********************/
 
-    constructor() Lib_ReentrancyGuard() internal {}
+    constructor() Lib_ReentrancyGuard() {}
 
     function xDomainMessageSender() public override view returns (address) {
         require(xDomainMsgSender != DEFAULT_XDOMAIN_SENDER, "xDomainMessageSender is not set");

--- a/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
@@ -111,12 +111,12 @@ abstract contract Abs_BaseCrossDomainMessenger is iAbs_BaseCrossDomainMessenger,
 
     /**
      * Sends a cross domain message.
-     * @param _message Message to send.
-     * @param _gasLimit Gas limit for the provided message.
+     * param // Message to send.
+     * param // Gas limit for the provided message.
      */
     function _sendXDomainMessage(
-        bytes memory _message,
-        uint256 _gasLimit
+        bytes memory, // _message,
+        uint256 // _gasLimit
     )
         virtual
         internal

--- a/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
@@ -122,11 +122,11 @@ contract OVM_L2CrossDomainMessenger is iOVM_L2CrossDomainMessenger, Abs_BaseCros
     /**
      * Sends a cross domain message.
      * @param _message Message to send.
-     * @param _gasLimit Gas limit for the provided message.
+     * param _gasLimit Gas limit for the provided message.
      */
     function _sendXDomainMessage(
         bytes memory _message,
-        uint256 _gasLimit
+        uint256 // _gasLimit
     )
         override
         internal

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -59,12 +59,12 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @dev Core logic to be performed when a withdrawal is finalized on L1.
      * In most cases, this will simply send locked funds to the withdrawer.
      *
-     * @param _to Address being withdrawn to.
-     * @param _amount Amount being withdrawn.
+     * param _to Address being withdrawn to.
+     * param _amount Amount being withdrawn.
      */
     function _handleFinalizeWithdrawal(
-        address _to,
-        uint256 _amount
+        address, // _to,
+        uint256 // _amount
     )
         internal
         virtual
@@ -76,14 +76,14 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @dev Core logic to be performed when a deposit is initiated on L1.
      * In most cases, this will simply send locked funds to the withdrawer.
      *
-     * @param _from Address being deposited from on L1.
-     * @param _to Address being deposited into on L2.
-     * @param _amount Amount being deposited.
+     * param _from Address being deposited from on L1.
+     * param _to Address being deposited into on L2.
+     * param _amount Amount being deposited.
      */
     function _handleInitiateDeposit(
-        address _from,
-        address _to,
-        uint256 _amount
+        address, // _from,
+        address, // _to,
+        uint256 // _amount
     )
         internal
         virtual

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -88,13 +88,13 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @dev Core logic to be performed when a withdrawal from L2 is initialized.
      * In most cases, this will simply burn the withdrawn L2 funds.
      *
-     * @param _to Address being withdrawn to
-     * @param _amount Amount being withdrawn
+     * param _to Address being withdrawn to
+     * param _amount Amount being withdrawn
      */
 
     function _handleInitiateWithdrawal(
-        address _to,
-        uint _amount
+        address, // _to,
+        uint // _amount
     )
         internal
         virtual
@@ -106,12 +106,12 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @dev Core logic to be performed when a deposit from L2 is finalized on L2.
      * In most cases, this will simply _mint() to credit L2 funds to the recipient.
      *
-     * @param _to Address being deposited to on L2
-     * @param _amount Amount which was deposited on L1
+     * param _to Address being deposited to on L2
+     * param _amount Amount which was deposited on L1
      */
     function _handleFinalizeDeposit(
-        address _to,
-        uint _amount
+        address, // _to
+        uint // _amount
     )
         internal
         virtual

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -61,12 +61,12 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
      * transfers the funds to itself for future withdrawals
      *
      * @param _from L1 address ETH is being deposited from
-     * @param _to L2 address that the ETH is being deposited to
+     * param _to L2 address that the ETH is being deposited to
      * @param _amount Amount of ERC20 to send
      */
     function _handleInitiateDeposit(
         address _from,
-        address _to,
+        address, // _to,
         uint256 _amount
     )
         internal

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2DepositedERC20.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2DepositedERC20.sol
@@ -45,7 +45,7 @@ contract OVM_L2DepositedERC20 is Abs_L2DepositedToken, UniswapV2ERC20 {
 
     // When a withdrawal is initiated, we burn the withdrawer's funds to prevent subsequent L2 usage.
     function _handleInitiateWithdrawal(
-        address _to,
+        address, // _to,
         uint _amount
     )
         internal

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -470,7 +470,6 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
                 curContext,
                 nextContext,
                 nextQueueIndex,
-                queueLength,
                 queueRef
             );
 
@@ -1008,14 +1007,12 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
      * @param _prevContext The previously validated batch context.
      * @param _nextContext The batch context to validate with this call.
      * @param _nextQueueIndex Index of the next queue element to process for the _nextContext's subsequentQueueElements.
-     * param _queueLength The length of the queue at the start of the batchAppend call.
      * @param _queueRef The storage container for the queue.
      */
     function _validateNextBatchContext(
         BatchContext memory _prevContext,
         BatchContext memory _nextContext,
         uint40 _nextQueueIndex,
-        uint40, // _queueLength,
         iOVM_ChainStorageContainer _queueRef
     )
         internal

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -341,6 +341,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     )
         override
         public
+        pure
     {
         // TEMPORARY: Disable `appendQueueBatch` for minnet
         revert("appendQueueBatch is currently disabled.");

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -334,10 +334,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
 
     /**
      * Appends a given number of queued transactions as a single batch.
-     * @param _numQueuedTransactions Number of transactions to append.
+     * param _numQueuedTransactions Number of transactions to append.
      */
     function appendQueueBatch(
-        uint256 _numQueuedTransactions
+        uint256 // _numQueuedTransactions
     )
         override
         public
@@ -1007,14 +1007,14 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
      * @param _prevContext The previously validated batch context.
      * @param _nextContext The batch context to validate with this call.
      * @param _nextQueueIndex Index of the next queue element to process for the _nextContext's subsequentQueueElements.
-     * @param _queueLength The length of the queue at the start of the batchAppend call.
+     * param _queueLength The length of the queue at the start of the batchAppend call.
      * @param _queueRef The storage container for the queue.
      */
     function _validateNextBatchContext(
         BatchContext memory _prevContext,
         BatchContext memory _nextContext,
         uint40 _nextQueueIndex,
-        uint40 _queueLength,
+        uint40, // _queueLength,
         iOVM_ChainStorageContainer _queueRef
     )
         internal

--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -187,16 +187,12 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
             return;
         }
 
-        // Check gas right before the call to get total gas consumed by OVM transaction.
-        uint256 gasProvided = gasleft();
-
         // Run the transaction, make sure to meter the gas usage.
         ovmCALL(
             _transaction.gasLimit - gasMeterConfig.minTransactionGasLimit,
             _transaction.entrypoint,
             _transaction.data
         );
-        uint256 gasUsed = gasProvided - gasleft();
 
         // TEMPORARY: Gas metering is disabled for minnet.
         // // Update the cumulative gas based on the amount of gas used.
@@ -632,8 +628,6 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         // DELEGATECALL does not change anything about the message context.
         MessageContext memory nextMessageContext = messageContext;
         
-        bool isStaticEntrypoint = false;
-
         return _callContract(
             nextMessageContext,
             _gasLimit,

--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -187,6 +187,10 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
             return;
         }
 
+        // TEMPORARY: Gas metering is disabled for minnet.
+        // // Check gas right before the call to get total gas consumed by OVM transaction.
+        // uint256 gasProvided = gasleft();
+
         // Run the transaction, make sure to meter the gas usage.
         ovmCALL(
             _transaction.gasLimit - gasMeterConfig.minTransactionGasLimit,
@@ -196,6 +200,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
 
         // TEMPORARY: Gas metering is disabled for minnet.
         // // Update the cumulative gas based on the amount of gas used.
+        // uint256 gasUsed = gasProvided - gasleft();
         // _updateCumulativeGas(gasUsed, _transaction.l1QueueOrigin);
 
         // Wipe the execution context.

--- a/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -1625,12 +1625,12 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     /**
      * Validates the gas limit for a given transaction.
      * @param _gasLimit Gas limit provided by the transaction.
-     * @param _queueOrigin Queue from which the transaction originated.
+     * param _queueOrigin Queue from which the transaction originated.
      * @return _valid Whether or not the gas limit is valid.
      */
     function _isValidGasLimit(
         uint256 _gasLimit,
-        Lib_OVMCodec.QueueOrigin _queueOrigin
+        Lib_OVMCodec.QueueOrigin // _queueOrigin
     )
         view
         internal

--- a/contracts/optimistic-ethereum/libraries/standards/UniswapV2ERC20.sol
+++ b/contracts/optimistic-ethereum/libraries/standards/UniswapV2ERC20.sol
@@ -22,7 +22,7 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
     constructor(
     string memory _name,
         string memory _symbol
-    ) public {
+    ) {
         name = _name;
         symbol = _symbol;
 

--- a/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -349,9 +349,6 @@ library Lib_RingBuffer {
         RingBufferContext memory _ctx
     )
         internal
-        returns (
-            bytes32
-        )
     {
         bytes32 contextA;
         bytes32 contextB;

--- a/contracts/optimistic-ethereum/mockOVM/accounts/mockOVM_ECDSAContractAccount.sol
+++ b/contracts/optimistic-ethereum/mockOVM/accounts/mockOVM_ECDSAContractAccount.sol
@@ -23,18 +23,18 @@ contract mockOVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
      * Executes a signed transaction.
      * @param _transaction Signed EOA transaction.
      * @param _signatureType Hashing scheme used for the transaction (e.g., ETH signed message).
-     * @param _v Signature `v` parameter.
-     * @param _r Signature `r` parameter.
-     * @param _s Signature `s` parameter.
+     * param _v Signature `v` parameter.
+     * param _r Signature `r` parameter.
+     * param _s Signature `s` parameter.
      * @return _success Whether or not the call returned (rather than reverted).
      * @return _returndata Data returned by the call.
      */
     function execute(
         bytes memory _transaction,
         Lib_OVMCodec.EOASignatureType _signatureType,
-        uint8 _v,
-        bytes32 _r,
-        bytes32 _s
+        uint8, // _v,
+        bytes32, // _r,
+        bytes32 // _s
     )
         override
         public

--- a/contracts/optimistic-ethereum/mockOVM/bridge/mockOVM_GenericCrossDomainMessenger.sol
+++ b/contracts/optimistic-ethereum/mockOVM/bridge/mockOVM_GenericCrossDomainMessenger.sol
@@ -40,7 +40,8 @@ contract mockOVM_GenericCrossDomainMessenger {
         public
     {
         xDomainMessageSender = _sender;
-        _target.call{gas: _gasLimit}(_message);
+        (bool success, ) = _target.call{gas: _gasLimit}(_message);
+        require(success, "Cross-domain message call reverted. Did you set your gas limit high enough?");
         xDomainMessageSender = address(0);
     }
 }

--- a/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
+++ b/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
@@ -73,8 +73,8 @@ contract mockOVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
     }
 
     function getGasSpent(
-        bytes32 _preStateRoot,
-        address _who
+        bytes32, // _preStateRoot,
+        address // _who
     )
         override
         public

--- a/contracts/test-helpers/Helper_ModifiableStorage.sol
+++ b/contracts/test-helpers/Helper_ModifiableStorage.sol
@@ -7,7 +7,6 @@ contract Helper_ModifiableStorage {
     constructor(
         address _target
     )
-        public
     {
         target[address(this)] = _target;
     }

--- a/contracts/test-helpers/Helper_PrecompileCaller.sol
+++ b/contracts/test-helpers/Helper_PrecompileCaller.sol
@@ -48,6 +48,6 @@ contract Helper_PrecompileCaller is Helper_SimpleProxy {
         )
     {
         callPrecompile(_precompile, _data);
-        return msg.sender;
+        return address(0); // unused: silence compiler
     }
 }

--- a/contracts/test-helpers/Helper_PrecompileCaller.sol
+++ b/contracts/test-helpers/Helper_PrecompileCaller.sol
@@ -43,10 +43,9 @@ contract Helper_PrecompileCaller is Helper_SimpleProxy {
         bytes memory _data
     )
         public
-        returns (
-            address
-        )
+        returns (address _l1MessageSender)
     {
         callPrecompile(_precompile, _data);
+        return msg.sender;
     }
 }

--- a/contracts/test-helpers/Helper_PrecompileCaller.sol
+++ b/contracts/test-helpers/Helper_PrecompileCaller.sol
@@ -43,7 +43,9 @@ contract Helper_PrecompileCaller is Helper_SimpleProxy {
         bytes memory _data
     )
         public
-        returns (address _l1MessageSender)
+        returns (
+            address
+        )
     {
         callPrecompile(_precompile, _data);
         return msg.sender;

--- a/contracts/test-helpers/Helper_SimpleProxy.sol
+++ b/contracts/test-helpers/Helper_SimpleProxy.sol
@@ -6,7 +6,6 @@ contract Helper_SimpleProxy {
     address internal target;
 
     constructor()
-        public
     {
         owner = msg.sender;
     }

--- a/contracts/test-helpers/Helper_TestRunner.sol
+++ b/contracts/test-helpers/Helper_TestRunner.sol
@@ -175,6 +175,7 @@ contract Helper_TestRunner {
 
     function _failStep()
         internal
+        pure
     {
         revert("Test step failed.");
     }

--- a/contracts/test-helpers/Helper_TestRunner.sol
+++ b/contracts/test-helpers/Helper_TestRunner.sol
@@ -24,15 +24,15 @@ contract Helper_TestRunner {
     {
         bytes32 namehash = keccak256(abi.encodePacked(_step.functionName));
         if (namehash == keccak256("evmRETURN")) {
-            bytes memory returndata = _step.functionData;
+            bytes memory functionData = _step.functionData;
             assembly {
-                return(add(returndata, 0x20), mload(returndata))
+                return(add(functionData, 0x20), mload(functionData))
             }
         }
         if (namehash == keccak256("evmREVERT")) {
-            bytes memory returndata = _step.functionData;
+            bytes memory functionData = _step.functionData;
             assembly {
-                revert(add(returndata, 0x20), mload(returndata))
+                revert(add(functionData, 0x20), mload(functionData))
             }
         }
         if (namehash == keccak256("evmINVALID")) {

--- a/contracts/test-helpers/Helper_TestRunner.sol
+++ b/contracts/test-helpers/Helper_TestRunner.sol
@@ -185,7 +185,6 @@ contract Helper_TestRunner_CREATE is Helper_TestRunner {
         bytes memory _bytecode,
         TestStep[] memory _steps
     )
-        public
     {
         if (_steps.length > 0) {
             runMultipleTestSteps(_steps);


### PR DESCRIPTION
## Description
Clears compiler warnings when compiling contracts. Each warning type is addressed within a single commit in this PR.

## Questions
- I wasn't sure if I addressed `Warning: Unnamed return variable can remain unassigned.` correctly. Specifically, I took out a return for one of the functions because it was not being used.
- For `unused local variable warning`, I took out a couple of local variables for calculating `gasUsed` which was not being used in the function. Is that okay?

## Metadata
### Fixes
- Fixes #255

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
