### PR TITLE
remove pushTwo and getTwo

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -313,14 +313,12 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
 
         iOVM_ChainStorageContainer queueRef = queue();
 
-        queueRef.pushTwo(
-            transactionHash,
-            timestampAndBlockNumber
-        );
+        queueRef.push(transactionHash);
+        queueRef.push(timestampAndBlockNumber);
 
         // The underlying queue data structure stores 2 elements
         // per insertion, so to get the real queue length we need
-        // to divide by 2 and subtract 1. See the usage of `pushTwo(..)`.
+        // to divide by 2 and subtract 1.
         uint256 queueIndex = queueRef.length() / 2 - 1;
         emit TransactionEnqueued(
             msg.sender,
@@ -751,11 +749,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     {
         // The underlying queue data structure stores 2 elements
         // per insertion, so to get the actual desired queue index
-        // we need to multiply by 2. See the usage of `pushTwo(..)`.
-        (
-            bytes32 transactionHash,
-            bytes32 timestampAndBlockNumber
-        ) = _queueRef.getTwo(uint40(_index * 2));
+        // we need to multiply by 2.
+        uint40 trueIndex = uint40(_index * 2);
+        bytes32 transactionHash = _queueRef.get(trueIndex);
+        bytes32 timestampAndBlockNumber = _queueRef.get(trueIndex + 1);
 
         uint40 elementTimestamp;
         uint40 elementBlockNumber;
@@ -786,7 +783,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     {
         // The underlying queue data structure stores 2 elements
         // per insertion, so to get the real queue length we need
-        // to divide by 2. See the usage of `pushTwo(..)`.
+        // to divide by 2.
         return uint40(_queueRef.length() / 2);
     }
 

--- a/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -145,35 +145,6 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */
-    function pushTwo(
-        bytes32 _objectA,
-        bytes32 _objectB
-    )
-        override
-        public
-        onlyOwner
-    {
-        buffer.pushTwo(_objectA, _objectB);
-    }
-
-    /**
-     * @inheritdoc iOVM_ChainStorageContainer
-     */
-    function pushTwo(
-        bytes32 _objectA,
-        bytes32 _objectB,
-        bytes27 _globalMetadata
-    )
-        override
-        public
-        onlyOwner
-    {
-        buffer.pushTwo(_objectA, _objectB, _globalMetadata);
-    }
-
-    /**
-     * @inheritdoc iOVM_ChainStorageContainer
-     */
     function get(
         uint256 _index
     )
@@ -185,23 +156,6 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
         )
     {
         return buffer.get(uint40(_index));
-    }
-
-    /**
-     * @inheritdoc iOVM_ChainStorageContainer
-     */
-    function getTwo(
-        uint256 _index
-    )
-        override
-        public
-        view
-        returns (
-            bytes32,
-            bytes32
-        )
-    {
-        return buffer.getTwo(uint40(_index));
     }
     
     /**

--- a/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
+++ b/contracts/optimistic-ethereum/iOVM/chain/iOVM_ChainStorageContainer.sol
@@ -66,31 +66,6 @@ interface iOVM_ChainStorageContainer {
         external;
 
     /**
-     * Pushes two objects into the container at the same time. A useful optimization.
-     * @param _objectA First 32 byte value to insert into the container.
-     * @param _objectB Second 32 byte value to insert into the container.
-     */
-    function pushTwo(
-        bytes32 _objectA,
-        bytes32 _objectB
-    )
-        external;
-
-    /**
-     * Pushes two objects into the container at the same time. Also allows setting the global
-     * metadata field.
-     * @param _objectA First 32 byte value to insert into the container.
-     * @param _objectB Second 32 byte value to insert into the container.
-     * @param _globalMetadata New global metadata for the container.
-     */
-    function pushTwo(
-        bytes32 _objectA,
-        bytes32 _objectB,
-        bytes27 _globalMetadata
-    )
-        external;
-
-    /**
      * Retrieves an object from the container.
      * @param _index Index of the particular object to access.
      * @return 32 byte object value.
@@ -101,22 +76,6 @@ interface iOVM_ChainStorageContainer {
         external
         view
         returns (
-            bytes32
-        );
-
-    /**
-     * Retrieves two consecutive objects from the container.
-     * @param _index Index of the particular objects to access.
-     * @return 32 byte object value at index `_index`.
-     * @return 32 byte object value at index `_index + 1`.
-     */
-    function getTwo(
-        uint256 _index
-    )
-        external
-        view
-        returns (
-            bytes32,
             bytes32
         );
 

--- a/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -112,47 +112,6 @@ library Lib_RingBuffer {
     }
 
     /**
-     * Pushes a two elements to the buffer.
-     * @param _self Buffer to access.
-     * @param _valueA First value to push to the buffer.
-     * @param _valueA Second value to push to the buffer.
-     * @param _extraData Optional global extra data.
-     */
-    function pushTwo(
-        RingBuffer storage _self,
-        bytes32 _valueA,
-        bytes32 _valueB,
-        bytes27 _extraData
-    )
-        internal
-    {
-        _self.push(_valueA, _extraData);
-        _self.push(_valueB, _extraData);
-    }
-
-    /**
-     * Pushes a two elements to the buffer.
-     * @param _self Buffer to access.
-     * @param _valueA First value to push to the buffer.
-     * @param _valueA Second value to push to the buffer.
-     */
-    function pushTwo(
-        RingBuffer storage _self,
-        bytes32 _valueA,
-        bytes32 _valueB
-    )
-        internal
-    {
-        RingBufferContext memory ctx = _self.getContext();
-
-        _self.pushTwo(
-            _valueA,
-            _valueB,
-            ctx.extraData
-        );
-    }
-
-    /**
      * Retrieves an element from the buffer.
      * @param _self Buffer to access.
      * @param _index Element index to retrieve.
@@ -209,30 +168,6 @@ library Lib_RingBuffer {
 
             return prevBuffer.buf[prevBuffer.length - relativeIndex];
         }
-    }
-
-    /**
-     * Retrieves two consecutive elements from the buffer.
-     * @param _self Buffer to access.
-     * @param _index Element index to retrieve.
-     * @return Value of the element at index `_index`.
-     * @return Value of the element at index `_index + 1`.
-     */
-    function getTwo(
-        RingBuffer storage _self,
-        uint256 _index
-    )
-        internal
-        view
-        returns (
-            bytes32,
-            bytes32
-        )
-    {
-        return (
-            _self.get(_index),
-            _self.get(_index + 1)
-        );
     }
 
     /**

--- a/contracts/test-libraries/utils/TestLib_RingBuffer.sol
+++ b/contracts/test-libraries/utils/TestLib_RingBuffer.sol
@@ -25,20 +25,6 @@ contract TestLib_RingBuffer {
         );
     }
 
-    function pushTwo(
-        bytes32 _valueA,
-        bytes32 _valueB,
-        bytes27 _extraData
-    )
-        public
-    {
-        buf.pushTwo(
-            _valueA,
-            _valueB,
-            _extraData
-        );
-    }
-
     function get(
         uint256 _index
     )


### PR DESCRIPTION
## Description

Current Chain storage containers on Kovan and Mainnet don't have pushTwo or getTwo, and they add a bit of complexity, so let's just remove them for now. The gas savings are minimal according to @smartcontracts, so I think we should be good there.

## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
