### PR TITLE
build: remove duplicate npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@eth-optimism/core-utils": "^0.1.8",
     "@eth-optimism/dev": "^1.1.1",
-    "@eth-optimism/core-utils": "^0.1.5",
     "@eth-optimism/solc": "^0.6.12-alpha.1",
     "@ethersproject/abstract-provider": "^5.0.8",
     "@ethersproject/contracts": "^5.0.5",

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.gas.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.gas.spec.ts
@@ -152,7 +152,7 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
         (transactionTemplate.slice(2).length / 2) * 16 * numTxs
 
       const res = await appendSequencerBatch(OVM_CanonicalTransactionChain, {
-        shouldStartAtBatch: 0,
+        shouldStartAtElement: 0,
         totalElementsToAppend: numTxs,
         contexts: [
           {
@@ -192,7 +192,7 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
         (transactionTemplate.slice(2).length / 2) * 16 * numTxs
 
       const res = await appendSequencerBatch(OVM_CanonicalTransactionChain, {
-        shouldStartAtBatch: 0,
+        shouldStartAtElement: 0,
         totalElementsToAppend: numTxs,
         contexts: [...Array(numTxs)].map(() => {
           return {

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -508,7 +508,7 @@ describe('OVM_CanonicalTransactionChain', () => {
       await appendSequencerBatch(
         OVM_CanonicalTransactionChain.connect(sequencer),
         {
-          shouldStartAtBatch: 0,
+          shouldStartAtElement: 0,
           totalElementsToAppend: 1,
           contexts: [
             {
@@ -612,7 +612,7 @@ describe('OVM_CanonicalTransactionChain', () => {
       await appendSequencerBatch(
         OVM_CanonicalTransactionChain.connect(sequencer),
         {
-          shouldStartAtBatch: 0,
+          shouldStartAtElement: 0,
           totalElementsToAppend: 1,
           contexts: [
             {
@@ -679,7 +679,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               blockNumber: 0,
             },
           ],
-          shouldStartAtBatch: 1234,
+          shouldStartAtElement: 1234,
           totalElementsToAppend: 1,
         })
       ).to.be.revertedWith(
@@ -702,7 +702,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               blockNumber,
             },
           ],
-          shouldStartAtBatch: 0,
+          shouldStartAtElement: 0,
           totalElementsToAppend: 1,
         })
       ).to.be.revertedWith('Not all sequencer transactions were processed.')
@@ -720,7 +720,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               blockNumber: 0,
             },
           ],
-          shouldStartAtBatch: 0,
+          shouldStartAtElement: 0,
           totalElementsToAppend: 1,
         })
       ).to.be.revertedWith('Function can only be called by the Sequencer.')
@@ -731,7 +731,7 @@ describe('OVM_CanonicalTransactionChain', () => {
         appendSequencerBatch(OVM_CanonicalTransactionChain, {
           transactions: ['0x1234'],
           contexts: [],
-          shouldStartAtBatch: 0,
+          shouldStartAtElement: 0,
           totalElementsToAppend: 1,
         })
       ).to.be.revertedWith('Must provide at least one batch context.')
@@ -749,7 +749,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               blockNumber: 0,
             },
           ],
-          shouldStartAtBatch: 0,
+          shouldStartAtElement: 0,
           totalElementsToAppend: 0,
         })
       ).to.be.revertedWith('Must append at least one element.')
@@ -776,7 +776,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   blockNumber,
                 },
               ],
-              shouldStartAtBatch: 0,
+              shouldStartAtElement: 0,
               totalElementsToAppend: 1,
             })
           ).to.be.revertedWith('Index out of bounds.')
@@ -802,7 +802,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   blockNumber,
                 },
               ],
-              shouldStartAtBatch: 0,
+              shouldStartAtElement: 0,
               totalElementsToAppend: numEnqueues + 1,
             })
           ).to.be.revertedWith('Not enough queued transactions to append.')
@@ -832,7 +832,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber,
                   },
                 ],
-                shouldStartAtBatch: 0,
+                shouldStartAtElement: 0,
                 totalElementsToAppend: 2,
               })
             ).to.be.revertedWith(
@@ -861,7 +861,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber,
                   },
                 ],
-                shouldStartAtBatch: 0,
+                shouldStartAtElement: 0,
                 totalElementsToAppend: 2,
               })
             ).to.be.revertedWith(
@@ -895,7 +895,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                       blockNumber,
                     },
                   ],
-                  shouldStartAtBatch: 0,
+                  shouldStartAtElement: 0,
                   totalElementsToAppend: 1,
                 })
               ).to.be.revertedWith(
@@ -919,7 +919,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                       blockNumber,
                     },
                   ],
-                  shouldStartAtBatch: 0,
+                  shouldStartAtElement: 0,
                   totalElementsToAppend: 1,
                 })
               ).to.be.revertedWith(
@@ -955,7 +955,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               await appendSequencerBatch(OVM_CanonicalTransactionChain, {
                 transactions: new Array(numQueuedTransactions).fill('0x1234'),
                 contexts: validContexts,
-                shouldStartAtBatch: 0,
+                shouldStartAtElement: 0,
                 totalElementsToAppend: 2 * numQueuedTransactions,
               })
             })
@@ -970,7 +970,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 appendSequencerBatch(OVM_CanonicalTransactionChain, {
                   transactions: new Array(numQueuedTransactions).fill('0x1234'),
                   contexts: invalidTimestampContexts,
-                  shouldStartAtBatch: 0,
+                  shouldStartAtElement: 0,
                   totalElementsToAppend: 2 * numQueuedTransactions,
                 })
               ).to.be.revertedWith(
@@ -988,7 +988,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 appendSequencerBatch(OVM_CanonicalTransactionChain, {
                   transactions: new Array(numQueuedTransactions).fill('0x1234'),
                   contexts: invalidBlockNumberContexts,
-                  shouldStartAtBatch: 0,
+                  shouldStartAtElement: 0,
                   totalElementsToAppend: 2 * numQueuedTransactions,
                 })
               ).to.be.revertedWith(
@@ -1016,7 +1016,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber,
                   },
                 ],
-                shouldStartAtBatch: 0,
+                shouldStartAtElement: 0,
                 totalElementsToAppend: 1,
               })
             ).to.be.revertedWith('Context timestamp is from the future.')
@@ -1043,7 +1043,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber,
                   },
                 ],
-                shouldStartAtBatch: 0,
+                shouldStartAtElement: 0,
                 totalElementsToAppend: 2,
               })
             ).to.be.revertedWith('Context timestamp is from the future.')
@@ -1064,7 +1064,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber,
                   },
                 ],
-                shouldStartAtBatch: 0,
+                shouldStartAtElement: 0,
                 totalElementsToAppend: 1,
               })
             ).to.be.revertedWith('Context block number is from the future.')
@@ -1092,7 +1092,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   blockNumber,
                 },
               ],
-              shouldStartAtBatch: 0,
+              shouldStartAtElement: 0,
               totalElementsToAppend: 1,
             })
           ).to.be.revertedWith('Context timestamp too far in the past.')
@@ -1116,7 +1116,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   blockNumber: 10,
                 },
               ],
-              shouldStartAtBatch: 0,
+              shouldStartAtElement: 0,
               totalElementsToAppend: 1,
             })
           ).to.be.revertedWith('Context block number too far in the past.')
@@ -1140,7 +1140,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   blockNumber,
                 },
               ],
-              shouldStartAtBatch: 0,
+              shouldStartAtElement: 0,
               totalElementsToAppend: 1,
             })
           })
@@ -1157,7 +1157,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber,
                   },
                 ],
-                shouldStartAtBatch: 1,
+                shouldStartAtElement: 1,
                 totalElementsToAppend: 1,
               })
             ).to.be.revertedWith(
@@ -1177,7 +1177,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber: blockNumber - 1,
                   },
                 ],
-                shouldStartAtBatch: 1,
+                shouldStartAtElement: 1,
                 totalElementsToAppend: 1,
               })
             ).to.be.revertedWith(
@@ -1202,7 +1202,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   blockNumber,
                 },
               ],
-              shouldStartAtBatch: 0,
+              shouldStartAtElement: 0,
               totalElementsToAppend: 2,
             })
           })
@@ -1219,7 +1219,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber,
                   },
                 ],
-                shouldStartAtBatch: 2,
+                shouldStartAtElement: 2,
                 totalElementsToAppend: 1,
               })
             ).to.be.revertedWith(
@@ -1239,7 +1239,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                     blockNumber: blockNumber - 1,
                   },
                 ],
-                shouldStartAtBatch: 2,
+                shouldStartAtElement: 2,
                 totalElementsToAppend: 1,
               })
             ).to.be.revertedWith(
@@ -1273,7 +1273,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 blockNumber,
               },
             ],
-            shouldStartAtBatch: 0,
+            shouldStartAtElement: 0,
             totalElementsToAppend: 1,
           })
         ).to.be.revertedWith(
@@ -1316,7 +1316,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 appendSequencerBatch(OVM_CanonicalTransactionChain, {
                   transactions,
                   contexts,
-                  shouldStartAtBatch: 0,
+                  shouldStartAtElement: 0,
                   totalElementsToAppend: size,
                 })
               )
@@ -1367,7 +1367,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 appendSequencerBatch(OVM_CanonicalTransactionChain, {
                   transactions,
                   contexts,
-                  shouldStartAtBatch: 0,
+                  shouldStartAtElement: 0,
                   totalElementsToAppend: size * 2,
                 })
               )
@@ -1407,7 +1407,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                 appendSequencerBatch(OVM_CanonicalTransactionChain, {
                   transactions,
                   contexts,
-                  shouldStartAtBatch: 0,
+                  shouldStartAtElement: 0,
                   totalElementsToAppend: size + spacing,
                 })
               )
@@ -1452,7 +1452,7 @@ describe('OVM_CanonicalTransactionChain', () => {
             {
               transactions,
               contexts,
-              shouldStartAtBatch: 0,
+              shouldStartAtElement: 0,
               totalElementsToAppend: size,
             }
           )

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,20 +51,16 @@
     ganache-core "^2.12.1"
     glob "^7.1.6"
 
-"@eth-optimism/core-utils@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.1.5.tgz#90b3f3d14b25abd8a210d78678d36e54f0c841f4"
-  integrity sha512-DLcHKFXcfoVb0yizfHeDGvgfHYb5DRRMnZyXLXIN0HNrAeavQEjgRFLOo/qy+xNjGI99LKSvyJtHP/C9ImJDag==
+"@eth-optimism/core-utils@^0.1.8":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.1.10.tgz#bbed838cb7c9354e8b90029c47b7556ceaa756bf"
+  integrity sha512-RyZ79yP1gJP8Clx6AqvoDiJzbOVQccsyj0OobwiNfO4gUU1Lpmz37zXsQITSO+3bKWj+ipxg2baZnJwfoTxl5g==
   dependencies:
     "@ethersproject/abstract-provider" "^5.0.9"
-    axios "^0.21.1"
-    body-parser "^1.19.0"
-    debug "^4.1.1"
-    dotenv "^8.2.0"
-    ethereumjs-util "^6.2.0"
-    ethers "^5.0.24"
-    express "^4.17.1"
-    uuid "^3.3.3"
+    colors "^1.4.0"
+    debug "^4.3.1"
+    ethers "^5.0.31"
+    pino "^6.11.1"
 
 "@eth-optimism/dev@^1.1.1":
   version "1.1.1"
@@ -1452,6 +1448,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 available-typed-arrays@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz#6b098ca9d8039079ee3f77f7b783c4480ba513f5"
@@ -1468,13 +1469,6 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -2121,7 +2115,7 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
-body-parser@1.19.0, body-parser@^1.16.0, body-parser@^1.19.0:
+body-parser@1.19.0, body-parser@^1.16.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -2660,6 +2654,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colors@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -3164,11 +3163,6 @@ domutils@^2.4.3, domutils@^2.4.4:
     dom-serializer "^1.0.1"
     domelementtype "^2.0.1"
     domhandler "^4.0.0"
-
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 dotignore@~0.1.2:
   version "0.1.2"
@@ -3848,7 +3842,7 @@ ethers@^4.0.0-beta.1, ethers@^4.0.32:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5, ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.14, ethers@^5.0.2, ethers@^5.0.24, ethers@^5.0.25, ethers@^5.0.31:
+ethers@^5, ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.14, ethers@^5.0.2, ethers@^5.0.25, ethers@^5.0.31:
   version "5.0.31"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.31.tgz#60e3b1425864fe5d2babc147ede01be8382a7d2a"
   integrity sha512-zpq0YbNFLFn+t+ibS8UkVWFeK5w6rVMSvbSHrHAQslfazovLnQ/mc2gdN5+6P45/k8fPgHrfHrYvJ4XvyK/S1A==
@@ -3951,7 +3945,7 @@ expand-template@^2.0.3:
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
-express@^4.14.0, express@^4.17.1:
+express@^4.14.0:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -4060,6 +4054,16 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fast-redact@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.0.0.tgz#ac2f9e36c9f4976f5db9fb18c6ffbaf308cf316d"
+  integrity sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==
+
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
@@ -4160,12 +4164,17 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
+flatstr@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
+
 flow-stoplight@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/flow-stoplight/-/flow-stoplight-1.0.0.tgz#4a292c5bcff8b39fa6cc0cb1a853d86f27eeff7b"
   integrity sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=
 
-follow-redirects@^1.10.0, follow-redirects@^1.12.1:
+follow-redirects@^1.12.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
   integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
@@ -6708,6 +6717,23 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+pino-std-serializers@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz#b56487c402d882eb96cd67c257868016b61ad671"
+  integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
+
+pino@^6.11.1:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.11.2.tgz#2f3d119c526651aab4ec3d280844785d52d0b690"
+  integrity sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==
+  dependencies:
+    fast-redact "^3.0.0"
+    fast-safe-stringify "^2.0.7"
+    flatstr "^1.0.12"
+    pino-std-serializers "^3.1.0"
+    quick-format-unescaped "4.0.1"
+    sonic-boom "^1.0.2"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -6942,6 +6968,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+quick-format-unescaped@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz#437a5ea1a0b61deb7605f8ab6a8fd3858dbeb701"
+  integrity sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==
 
 random-bytes-seed@^1.0.3:
   version "1.0.3"
@@ -7581,6 +7612,14 @@ solc@^0.6.3:
     require-from-string "^2.0.0"
     semver "^5.5.0"
     tmp "0.0.33"
+
+sonic-boom@^1.0.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-1.4.0.tgz#d6d35196c32609b46193145afc1174a8c692d21e"
+  integrity sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    flatstr "^1.0.12"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -8453,7 +8492,7 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
Noticed we have `core-utils` listed twice. Seems like the tests fail when removing the older one.