### PR TITLE
fix: Stricter RLP boolean checking

### DIFF
--- a/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
+++ b/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
@@ -353,6 +353,11 @@ library Lib_RLPReader {
             out := byte(0, mload(ptr))
         }
 
+        require(
+            out == 0 || out == 1,
+            "Lib_RLPReader: Invalid RLP boolean value, must be 0 or 1"
+        );
+
         return out != 0;
     }
 

--- a/test/data/json/libraries/rlp/Lib_RLPReader.test.json
+++ b/test/data/json/libraries/rlp/Lib_RLPReader.test.json
@@ -16,6 +16,12 @@
                 "out": [
                     false
                 ]
+            },
+            "something other than 0 or 1 (should revert)": {
+                "in": [
+                    "0x02"
+                ],
+                "revert": true
             }
         },
         "readAddress": {


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Minor fix, handles an issue pointed out by proto. Geth is much stricter than `Lib_RLPReader` about checking the validity of boolean values. This PR fixes that discrepancy and explicitly checks that the boolean value is either 0 or 1.

**Metadata**
- Fixes proto#42
