### PR TITLE
Add 'from' to `finalizeWithdrawal` in Standard Bridge Interface

### DIFF
--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -64,6 +64,7 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      */
     function _handleFinalizeWithdrawal(
         address, // _to,
+        address, // _from,
         uint256 // _amount
     )
         internal
@@ -188,22 +189,25 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * This call will fail if the initialized withdrawal from L2 has not been finalized. 
      *
      * @param _to L1 address to credit the withdrawal to
+     * @param _from address that started withdrawal
      * @param _amount Amount of the ERC20 to withdraw
      */
     function finalizeWithdrawal(
         address _to,
+        address _from,
         uint _amount
     )
         external
-        override 
+        override
         onlyFromCrossDomainAccount(l2DepositedToken)
     {
         // Call our withdrawal accounting handler implemented by child contracts.
         _handleFinalizeWithdrawal(
             _to,
+            _from,
             _amount
         );
 
-        emit WithdrawalFinalized(_to, _amount);
+        emit WithdrawalFinalized(_to, _from, _amount);
     }
 }

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -152,7 +152,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         override
         onlyInitialized()
     {
-        _initiateWithdrawal(msg.sender, _amount);
+        _initiateWithdrawal(msg.sender, msg.sender, _amount);
     }
 
     /**
@@ -168,17 +168,19 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         override
         onlyInitialized()
     {
-        _initiateWithdrawal(_to, _amount);
+        _initiateWithdrawal(_to, msg.sender, _amount);
     }
 
     /**
      * @dev Performs the logic for deposits by storing the token and informing the L2 token Gateway of the deposit.
      *
      * @param _to Account to give the withdrawal to on L1
+     * @param _from Account to take the withdrawal on L2
      * @param _amount Amount of the token to withdraw
      */
     function _initiateWithdrawal(
         address _to,
+        address _from,
         uint _amount
     )
         internal
@@ -190,6 +192,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         bytes memory data = abi.encodeWithSelector(
             iOVM_L1TokenGateway.finalizeWithdrawal.selector,
             _to,
+            _from,
             _amount
         );
 

--- a/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// @unsupported: ovm 
+// @unsupported: ovm
 pragma solidity >0.5.0 <0.8.0;
 pragma experimental ABIEncoderV2;
 
@@ -27,7 +27,7 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
     /********************************
      * External Contract References *
      ********************************/
-    
+
     iOVM_ERC20 public l1ERC20;
 
     /***************
@@ -41,7 +41,7 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
     constructor(
         iOVM_ERC20 _l1ERC20,
         address _l2DepositedERC20,
-        address _l1messenger 
+        address _l1messenger
     )
         Abs_L1TokenGateway(
             _l2DepositedERC20,
@@ -85,10 +85,12 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
      * transfers the funds to the withdrawer
      *
      * @param _to L1 address that the ERC20 is being withdrawn to
+     * @param _from address that started withdrawal
      * @param _amount Amount of ERC20 to send
      */
     function _handleFinalizeWithdrawal(
         address _to,
+        address _from,
         uint _amount
     )
         internal

--- a/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -19,6 +19,7 @@ interface iOVM_L1TokenGateway {
   
     event WithdrawalFinalized(
         address indexed _to,
+        address _from,
         uint256 _amount
     );
 
@@ -45,6 +46,7 @@ interface iOVM_L1TokenGateway {
 
     function finalizeWithdrawal(
         address _to,
+        address _from,
         uint _amount
     )
         external;

--- a/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
+++ b/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
@@ -81,7 +81,11 @@ describe('OVM_L1ERC20Gateway', () => {
       )
 
       await expect(
-        OVM_L1ERC20Gateway.finalizeWithdrawal(constants.AddressZero, 1)
+        OVM_L1ERC20Gateway.finalizeWithdrawal(
+          constants.AddressZero,
+          constants.AddressZero,
+          1
+        )
       ).to.be.revertedWith(ERR_INVALID_MESSENGER)
     })
 
@@ -91,9 +95,14 @@ describe('OVM_L1ERC20Gateway', () => {
       )
 
       await expect(
-        OVM_L1ERC20Gateway.finalizeWithdrawal(constants.AddressZero, 1, {
-          from: Mock__OVM_L1CrossDomainMessenger.address,
-        })
+        OVM_L1ERC20Gateway.finalizeWithdrawal(
+          constants.AddressZero,
+          constants.AddressZero,
+          1,
+          {
+            from: Mock__OVM_L1CrossDomainMessenger.address,
+          }
+        )
       ).to.be.revertedWith(ERR_INVALID_X_DOMAIN_MSG_SENDER)
     })
 
@@ -109,6 +118,7 @@ describe('OVM_L1ERC20Gateway', () => {
       await L1ERC20.transfer(OVM_L1ERC20Gateway.address, withdrawalAmount)
 
       const res = await OVM_L1ERC20Gateway.finalizeWithdrawal(
+        NON_ZERO_ADDRESS,
         NON_ZERO_ADDRESS,
         withdrawalAmount,
         { from: Mock__OVM_L1CrossDomainMessenger.address }

--- a/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
+++ b/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
@@ -149,7 +149,7 @@ describe('OVM_L2DepositedERC20', () => {
       expect(withdrawalCallToMessenger._message).to.equal(
         await Factory__OVM_L1ERC20Gateway.interface.encodeFunctionData(
           'finalizeWithdrawal',
-          [await alice.getAddress(), withdrawAmount]
+          [await alice.getAddress(), await alice.getAddress(), withdrawAmount]
         )
       )
       // Hardcoded gaslimit should be correct
@@ -184,7 +184,7 @@ describe('OVM_L2DepositedERC20', () => {
       expect(withdrawalCallToMessenger._message).to.equal(
         await Factory__OVM_L1ERC20Gateway.interface.encodeFunctionData(
           'finalizeWithdrawal',
-          [await bob.getAddress(), withdrawAmount]
+          [await bob.getAddress(), await alice.getAddress(), withdrawAmount]
         )
       )
       // Hardcoded gaslimit should be correct


### PR DESCRIPTION
**Description**
Add `from` field to `iOVM_L1TokenGateway`'s `finalizeWithdrawal`. This adds more context to cross-chain messages and allows to build 3rd party fast withdrawal solutions OUTSIDE of the token bridge.

**Additional context**
FW solution flow possible after this change:
1. Alice calls `withdrawTo` on `L2DepositedToken` with an address of a smartcontract coordinating FW let's call it `Coordinator`.
2. A liqudity provider Bob validates that withdrawal is correct.
3. Bob sends Alice funds on L1 by letting `Coordinator` to send his funds to Alice and record this fact. Alice can enjoy their token on L1.
4. When Alice's withdrawal settles, Bob claims it as he can proof that he already sent Alice funds.

If (3) never happened, after withdrawal settles, Alice proofs that she initiated the original withdraw and she claims tokens. Without the change described in this PR a crosschain message only contains address of a Coordinator SC (`to` field) and hence Alice can not proof that she originated the withdrawal. 

PoC of such solution was implemented by @gakonst in: https://github.com/gakonst/optimistic-fast-withdrawals/blob/feat/fast-withdrawals/contracts/MarketMaker.sol

Alice and Bob can negotiate additional fees in a state channel and they don't have to be part of the cross-chain message.

**Other implementations**
A similar effect can be achieved by adding `extraData` instead of `from` but this could produce multiple similar yet different implementations in the wild.
