### PR TITLE
Refactor repeatable hh-deploy code to helper function

### DIFF
--- a/deploy/001-OVM_ChainStorageContainer_ctc_batches.deploy.ts
+++ b/deploy/001-OVM_ChainStorageContainer_ctc_batches.deploy.ts
@@ -2,35 +2,16 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_ChainStorageContainer:CTC:batches', {
+    name: 'OVM_ChainStorageContainer:CTC:batches',
     contract: 'OVM_ChainStorageContainer',
-    from: deployer,
-    args: [Lib_AddressManager.address, 'OVM_CanonicalTransactionChain'],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    args: ['OVM_CanonicalTransactionChain'],
   }
-
-  await Lib_AddressManager.setAddress(
-    'OVM_ChainStorageContainer:CTC:batches',
-    result.address
-  )
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/002-OVM_ChainStorageContainer_ctc_queue.deploy.ts
+++ b/deploy/002-OVM_ChainStorageContainer_ctc_queue.deploy.ts
@@ -2,35 +2,16 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_ChainStorageContainer:CTC:queue', {
+    name: 'OVM_ChainStorageContainer:CTC:queue',
     contract: 'OVM_ChainStorageContainer',
-    from: deployer,
-    args: [Lib_AddressManager.address, 'OVM_CanonicalTransactionChain'],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    args: ['OVM_CanonicalTransactionChain'],
   }
-
-  await Lib_AddressManager.setAddress(
-    'OVM_ChainStorageContainer:CTC:queue',
-    result.address
-  )
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
+++ b/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
@@ -2,35 +2,16 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_ChainStorageContainer:SCC:queue', {
+    name: 'OVM_ChainStorageContainer:SCC:queue',
     contract: 'OVM_ChainStorageContainer',
-    from: deployer,
-    args: [Lib_AddressManager.address, 'OVM_StateCommitmentChain'],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    args: ['OVM_StateCommitmentChain'],
   }
-
-  await Lib_AddressManager.setAddress(
-    'OVM_ChainStorageContainer:SCC:queue',
-    result.address
-  )
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
+++ b/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
@@ -2,39 +2,19 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_CanonicalTransactionChain', {
-    from: deployer,
+    name: 'OVM_CanonicalTransactionChain',
     args: [
-      Lib_AddressManager.address,
       (hre as any).deployConfig.ctcForceInclusionPeriodSeconds,
       (hre as any).deployConfig.ctcForceInclusionPeriodBlocks,
       (hre as any).deployConfig.ctcMaxTransactionGasLimit,
     ],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
   }
-
-  await Lib_AddressManager.setAddress(
-    'OVM_CanonicalTransactionChain',
-    result.address
-  )
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/005-OVM_StateCommitmentChain.deploy.ts
+++ b/deploy/005-OVM_StateCommitmentChain.deploy.ts
@@ -2,38 +2,18 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_StateCommitmentChain', {
-    from: deployer,
+    name: 'OVM_StateCommitmentChain',
     args: [
-      Lib_AddressManager.address,
       (hre as any).deployConfig.sccFraudProofWindow,
       (hre as any).deployConfig.sccSequencerPublishWindow,
     ],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
   }
-
-  await Lib_AddressManager.setAddress(
-    'OVM_StateCommitmentChain',
-    result.address
-  )
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/006-OVM_ExecutionManager.deploy.ts
+++ b/deploy/006-OVM_ExecutionManager.deploy.ts
@@ -2,24 +2,13 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_ExecutionManager', {
-    from: deployer,
+    name: 'OVM_ExecutionManager',
     args: [
-      Lib_AddressManager.address,
       {
         minTransactionGasLimit: (hre as any).deployConfig
           .emMinTransactionGasLimit,
@@ -33,14 +22,8 @@ const deployFn: DeployFunction = async (hre) => {
         ovmCHAINID: (hre as any).deployConfig.emOvmChainId,
       },
     ],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
   }
-
-  await Lib_AddressManager.setAddress('OVM_ExecutionManager', result.address)
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/007-OVM_FraudVerifier.deploy.ts
+++ b/deploy/007-OVM_FraudVerifier.deploy.ts
@@ -2,31 +2,15 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_FraudVerifier', {
-    from: deployer,
-    args: [Lib_AddressManager.address],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    name: 'OVM_FraudVerifier',
+    args: [],
   }
-
-  await Lib_AddressManager.setAddress('OVM_FraudVerifier', result.address)
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/008-mockOVM_BondManager.deploy.ts
+++ b/deploy/008-mockOVM_BondManager.deploy.ts
@@ -16,6 +16,7 @@ const deployFn: DeployFunction = async (hre) => {
     }
   )
 
+  // TODO: Why is this mocked?
   const result = await deploy('mockOVM_BondManager', {
     from: deployer,
     args: [Lib_AddressManager.address],

--- a/deploy/009-OVM_SafetyChecker.deploy.ts
+++ b/deploy/009-OVM_SafetyChecker.deploy.ts
@@ -2,31 +2,16 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_SafetyChecker', {
-    from: deployer,
+    name: 'OVM_SafetyChecker',
     args: [],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    withAddressManager: false,
   }
-
-  await Lib_AddressManager.setAddress('OVM_SafetyChecker', result.address)
+  await deploy(cfg)
 }
 
 deployFn.tags = ['OVM_SafetyChecker']

--- a/deploy/010-OVM_StateManagerFactory.deploy.ts
+++ b/deploy/010-OVM_StateManagerFactory.deploy.ts
@@ -2,31 +2,16 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_StateManagerFactory', {
-    from: deployer,
+    name: 'OVM_StateManagerFactory',
     args: [],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    withAddressManager: false,
   }
-
-  await Lib_AddressManager.setAddress('OVM_StateManagerFactory', result.address)
+  await deploy(cfg)
 }
 
 deployFn.tags = ['OVM_StateManagerFactory']

--- a/deploy/011-OVM_StateTransitionerFactory.deploy.ts
+++ b/deploy/011-OVM_StateTransitionerFactory.deploy.ts
@@ -2,34 +2,15 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_StateTransitionerFactory', {
-    from: deployer,
-    args: [Lib_AddressManager.address],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    name: 'OVM_StateTransitionerFactory',
+    args: [],
   }
-
-  await Lib_AddressManager.setAddress(
-    'OVM_StateTransitionerFactory',
-    result.address
-  )
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/012-OVM_L1MultiMessageRelayer.deploy.ts
+++ b/deploy/012-OVM_L1MultiMessageRelayer.deploy.ts
@@ -2,34 +2,15 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { deploy } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deploy } = hre.deployments
-  const { deployer } = await hre.getNamedAccounts()
-
-  const Lib_AddressManager = await getDeployedContract(
+  const cfg = {
     hre,
-    'Lib_AddressManager',
-    {
-      signerOrProvider: deployer,
-    }
-  )
-
-  const result = await deploy('OVM_L1MultiMessageRelayer', {
-    from: deployer,
-    args: [Lib_AddressManager.address],
-    log: true,
-  })
-
-  if (!result.newlyDeployed) {
-    return
+    name: 'OVM_L1MultiMessageRelayer',
+    args: [],
   }
-
-  await Lib_AddressManager.setAddress(
-    'OVM_L1MultiMessageRelayer',
-    result.address
-  )
+  await deploy(cfg)
 }
 
 deployFn.dependencies = ['Lib_AddressManager']


### PR DESCRIPTION
As title, should make the https://github.com/ethereum-optimism/contracts/pull/249 more easy to review. 

This can be abstracted a bit more on the proxies. 

Q: Why are we using a mock ovm bond manager?