### PR TITLE
Make the libAddressManager variable public

### DIFF
--- a/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressResolver.sol
+++ b/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressResolver.sol
@@ -13,7 +13,7 @@ abstract contract Lib_AddressResolver {
      * Contract Variables: Contract References *
      *******************************************/
 
-    Lib_AddressManager internal libAddressManager;
+    Lib_AddressManager public libAddressManager;
 
 
     /***************


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The `libAddressManager` variable is currently internal and isn't easily accessible from the outside. Ideally this variable should be public so we have more visibility into the state of our contracts. Particularly important for doing post-deployment verification for proxies (which are initialized outside of the constructor).
