### PR TITLE
Enforce MAX_ROLLUP_TX_SIZE on sequencer tx

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -480,6 +480,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
                 assembly {
                     txDataLength := shr(232, calldataload(nextTransactionPtr))
                 }
+                require(
+                    txDataLength <= MAX_ROLLUP_TX_SIZE,
+                    "Transaction data size exceeds maximum for rollup transaction."
+                );
 
                 leaves[leafIndex] = _getSequencerLeafHash(
                     curContext,
@@ -937,7 +941,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         internal
         view
     {
-        // If there are existing elements, this batch must have the same context 
+        // If there are existing elements, this batch must have the same context
         // or a later timestamp and block number.
         if (getTotalElements() > 0) {
             (,, uint40 lastTimestamp, uint40 lastBlockNumber) = _getBatchExtraData();

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -754,6 +754,32 @@ describe('OVM_CanonicalTransactionChain', () => {
       ).to.be.revertedWith('Must append at least one element.')
     })
 
+    it('should revert when trying to input more data than the max data size', async () => {
+      const MAX_ROLLUP_TX_SIZE = await OVM_CanonicalTransactionChain.MAX_ROLLUP_TX_SIZE()
+      const data = '0x' + '12'.repeat(MAX_ROLLUP_TX_SIZE + 1)
+
+      const timestamp = await getEthTime(ethers.provider)
+      const blockNumber = (await getNextBlockNumber(ethers.provider)) - 1
+
+      await expect(
+        appendSequencerBatch(OVM_CanonicalTransactionChain, {
+          transactions: [data],
+          contexts: [
+            {
+              numSequencedTransactions: 1,
+              numSubsequentQueueTransactions: 0,
+              timestamp,
+              blockNumber,
+            },
+          ],
+          shouldStartAtElement: 0,
+          totalElementsToAppend: 1,
+        })
+      ).to.be.revertedWith(
+        'Transaction data size exceeds maximum for rollup transaction.'
+      )
+    })
+
     describe('Sad path cases', () => {
       const target = NON_ZERO_ADDRESS
       const gasLimit = 500_000


### PR DESCRIPTION
`MAX_ROLLUP_TX_SIZE` was enforced on `enqueue()` but not on `appendSequencerBatch()`.