### PR TITLE
fix: increase MAX_ROLLUP_TX_SIZE

### DIFF
--- a/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -38,7 +38,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
 
     // L2 tx gas-related
     uint256 constant public MIN_ROLLUP_TX_GAS = 100000;
-    uint256 constant public MAX_ROLLUP_TX_SIZE = 10000;
+    uint256 constant public MAX_ROLLUP_TX_SIZE = 50000;
     uint256 constant public L2_GAS_DISCOUNT_DIVISOR = 32;
 
     // Encoding-related (all in bytes)

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -188,7 +188,7 @@ describe('OVM_CanonicalTransactionChain', () => {
       const data = '0x' + '12'.repeat(MAX_ROLLUP_TX_SIZE + 1)
 
       await expect(
-        OVM_CanonicalTransactionChain.enqueue(target, gasLimit, data)
+        OVM_CanonicalTransactionChain.enqueue(target, gasLimit, data, { gasLimit: 40000000 })
       ).to.be.revertedWith(
         'Transaction data size exceeds maximum for rollup transaction.'
       )

--- a/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -188,7 +188,9 @@ describe('OVM_CanonicalTransactionChain', () => {
       const data = '0x' + '12'.repeat(MAX_ROLLUP_TX_SIZE + 1)
 
       await expect(
-        OVM_CanonicalTransactionChain.enqueue(target, gasLimit, data, { gasLimit: 40000000 })
+        OVM_CanonicalTransactionChain.enqueue(target, gasLimit, data, {
+          gasLimit: 40000000,
+        })
       ).to.be.revertedWith(
         'Transaction data size exceeds maximum for rollup transaction.'
       )


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Bumps the MAX_ROLLUP_TX_SIZE to a more reasonable value so that the new enforcement on sequencer transactions still allows things like large contract deployments.