### PR TITLE
fix: Check for overflows in safety checker

### DIFF
--- a/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
+++ b/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
@@ -57,12 +57,17 @@ contract OVM_SafetyChecker is iOVM_SafetyChecker {
         // PUSH opcodes
         uint256 opcodePushMask = ~uint256(0xffffffff000000000000000000000000);
 
-        uint256 codeLength;
         uint256 _pc;
         assembly {
             _pc := add(_bytecode, 0x20)
         }
-        codeLength = _pc + _bytecode.length;
+        uint256 codeLength = _pc + _bytecode.length;
+
+        // Simple overflow check.
+        if (codeLength < _pc) {
+            return false;
+        }
+
         do {
             // current opcode: 0x00...0xff
             uint256 opNum;


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a check to prevent overflows in the safety checker. Prevents the chance that an overflow here can be used to exploit the safety checker. Currently this is *not* an exploitable issue but it's better to be safe than sorry!