### PR TITLE
cleanup: Use standard registerAddress fn in deploy

### DIFF
--- a/deploy/006-mockOVM_BondManager.deploy.ts
+++ b/deploy/006-mockOVM_BondManager.deploy.ts
@@ -2,7 +2,10 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import {
+  getDeployedContract,
+  registerAddress,
+} from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deploy } = hre.deployments
@@ -26,7 +29,11 @@ const deployFn: DeployFunction = async (hre) => {
     return
   }
 
-  await Lib_AddressManager.setAddress('OVM_BondManager', result.address)
+  await registerAddress({
+    hre,
+    name: 'OVM_BondManager',
+    address: result.address,
+  })
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
+++ b/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
@@ -2,7 +2,10 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import {
+  getDeployedContract,
+  registerAddress,
+} from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deploy } = hre.deployments
@@ -50,10 +53,11 @@ const deployFn: DeployFunction = async (hre) => {
     )
   }
 
-  await Lib_AddressManager.setAddress(
-    'OVM_L1CrossDomainMessenger',
-    result.address
-  )
+  await registerAddress({
+    hre,
+    name: 'OVM_L1CrossDomainMessenger',
+    address: OVM_L1CrossDomainMessenger.address,
+  })
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
+++ b/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
@@ -2,7 +2,10 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import {
+  getDeployedContract,
+  registerAddress,
+} from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deploy } = hre.deployments
@@ -49,10 +52,11 @@ const deployFn: DeployFunction = async (hre) => {
     )
   }
 
-  await Lib_AddressManager.setAddress(
-    'Proxy__OVM_L1CrossDomainMessenger',
-    result.address
-  )
+  await registerAddress({
+    hre,
+    name: 'Proxy__OVM_L1CrossDomainMessenger',
+    address: Proxy__OVM_L1CrossDomainMessenger.address,
+  })
 }
 
 deployFn.dependencies = ['Lib_AddressManager', 'OVM_L1CrossDomainMessenger']

--- a/deploy/015-OVM_L1ETHGateway.deploy.ts
+++ b/deploy/015-OVM_L1ETHGateway.deploy.ts
@@ -2,7 +2,10 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import {
+  getDeployedContract,
+  registerAddress,
+} from '../src/hardhat-deploy-ethers'
 import { predeploys } from '../src/predeploys'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -50,7 +53,11 @@ const deployFn: DeployFunction = async (hre) => {
     )
   }
 
-  await Lib_AddressManager.setAddress('OVM_L1ETHGateway', result.address)
+  await registerAddress({
+    hre,
+    name: 'OVM_L1ETHGateway',
+    address: OVM_L1ETHGateway.address,
+  })
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/deploy/016-Proxy__OVM_L1ETHGateway.deploy.ts
+++ b/deploy/016-Proxy__OVM_L1ETHGateway.deploy.ts
@@ -2,7 +2,10 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import {
+  getDeployedContract,
+  registerAddress,
+} from '../src/hardhat-deploy-ethers'
 import { predeploys } from '../src/predeploys'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -53,7 +56,11 @@ const deployFn: DeployFunction = async (hre) => {
     )
   }
 
-  await Lib_AddressManager.setAddress('Proxy__OVM_L1ETHGateway', result.address)
+  await registerAddress({
+    hre,
+    name: 'Proxy__OVM_L1ETHGateway',
+    address: Proxy__OVM_L1ETHGateway.address,
+  })
 }
 
 deployFn.dependencies = ['Lib_AddressManager', 'OVM_L1ETHGateway']


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
A few minor tweaks to our deploy to use the standard `registerAddress` instead of a few stragglers that were calling `Lib_AddressManager` directly.